### PR TITLE
Automatic arguments to Python def docstrings

### DIFF
--- a/python-mode/.yas-setup.el
+++ b/python-mode/.yas-setup.el
@@ -1,0 +1,17 @@
+(defun python-split-args (arg-string)
+  "Split a python argument string into ((name, default)..) tuples"
+  (mapcar '(lambda (x)
+             (split-string x "[[:blank:]]*=[[:blank:]]*" t))
+          (split-string arg-string "[[:blank:]]*,[[:blank:]]*" t)))
+
+(defun python-args-to-docstring ()
+  "return docstring format for the python arguments in yas-text"
+  (let* ((indent (concat "\n" (make-string (current-column) 32)))
+         (args (mapconcat
+                '(lambda (x)
+                   (concat (nth 0 x) " -- "
+                           (if (nth 1 x) (concat "\(default " (nth 1 x) "\)"))))
+                (python-split-args yas-text)
+                indent)))
+    (unless (string= args "")
+      (mapconcat 'identity (list "Keyword Arguments:" args) indent))))

--- a/python-mode/function_docstring
+++ b/python-mode/function_docstring
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: function_docstring
+# key: fd
+# group: definitions
+# --
+def ${1:name}($2):
+    \"\"\"$3
+    ${2:$(python-args-to-docstring)}
+    \"\"\"
+    $0

--- a/python-mode/init_docstring
+++ b/python-mode/init_docstring
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: init_docstring
+# key: id
+# group : definitions
+# --
+def __init__(self$1):
+    \"\"\"$2
+    ${1:$(python-args-to-docstring)}
+    \"\"\"
+    $0

--- a/python-mode/method_docstring
+++ b/python-mode/method_docstring
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: method_docstring
+# key: md
+# group: object oriented
+# --
+def ${1:name}(self$2):
+    \"\"\"$3
+    ${2:$(python-args-to-docstring)}
+    \"\"\"
+    $0


### PR DESCRIPTION
Automatically generates docstrings skeleton for python method arguments.  e.g.

```
def foo(bar, baz=False):
    """
    Keyword Arguments:
    bar --
    baz -- (default False)
    """
```

In response to typing: `def<tab>foo<tab>bar, baz=False<tab>`

I'm submitting this for review anticipating changes, because:
1.  I have identical lisp in these two snippets.  Is there a way in the context of this repo to avoid this duplication?
2.  There are other python snippets which could benefit from this too (`init` is an obvious one).  If there's a way to resolve #1 I'd like to do that before hitting those
3.  While this is the format example in PEP-257, it's not mandatory.  Could consider other formats, like ":param foo" etc..?

Thoughts? 
