### PR TITLE
align '--' in Python docstring arg list

### DIFF
--- a/python-mode/.yas-setup.el
+++ b/python-mode/.yas-setup.el
@@ -7,11 +7,13 @@
 (defun python-args-to-docstring ()
   "return docstring format for the python arguments in yas-text"
   (let* ((indent (concat "\n" (make-string (current-column) 32)))
-         (args (mapconcat
+         (args (python-split-args yas-text))
+         (max-len (if args (apply 'max (mapcar '(lambda (x) (length (nth 0 x))) args)) 0))
+         (formatted-args (mapconcat
                 '(lambda (x)
-                   (concat (nth 0 x) " -- "
+                   (concat (nth 0 x) (make-string (- max-len (length (nth 0 x))) ? ) " -- "
                            (if (nth 1 x) (concat "\(default " (nth 1 x) "\)"))))
-                (python-split-args yas-text)
+                args
                 indent)))
-    (unless (string= args "")
-      (mapconcat 'identity (list "Keyword Arguments:" args) indent))))
+    (unless (string= formatted-args "")
+      (mapconcat 'identity (list "Keyword Arguments:" formatted-args) indent))))


### PR DESCRIPTION
Tweak to recently added function python-args-to-docstring.

Now it will align the '--' to look like this:

```
def my_func(foo, barbar=0, bazbazbaz = False)
    """

    Keyword Arguments:
    foo       --
    barbar    -- (default 0)
    bazbazbaz -- (default False)
    """
```
