### PR TITLE
inc and inc.1 should set a key

### DIFF
--- a/cc-mode/inc
+++ b/cc-mode/inc
@@ -1,3 +1,4 @@
 #name : #include "..."
+#key  : inc
 # --
 #include "$1"

--- a/cc-mode/inc.1
+++ b/cc-mode/inc.1
@@ -1,3 +1,4 @@
 #name : #include <...>
+#key  : inc
 # --
 #include <$1>


### PR DESCRIPTION
Without a key it is necessary to use inc.1 to get the second type of include. This shouldn't be the case.
