### PR TITLE
Replace some legacy usage of 'text' with 'yas-text'

### DIFF
--- a/c++-mode/class
+++ b/c++-mode/class
@@ -5,7 +5,7 @@
 class ${1:Name}
 {
 public:
-    ${1:$(yas/substr text "[^: ]*")}();
-    ${2:virtual ~${1:$(yas/substr text "[^: ]*")}();}
+    ${1:$(yas/substr yas-text "[^: ]*")}();
+    ${2:virtual ~${1:$(yas/substr yas-text "[^: ]*")}();}
 };
 $0

--- a/csharp-mode/attrib.2
+++ b/csharp-mode/attrib.2
@@ -5,7 +5,7 @@
 /// <summary>
 /// $3
 /// </summary>
-private $1 ${2:$(if (> (length text) 0) (format "_%s%s" (downcase (substring text 0 1)) (substring text 1 (length text))) "")};
+private $1 ${2:$(if (> (length yas-text) 0) (format "_%s%s" (downcase (substring yas-text 0 1)) (substring yas-text 1 (length yas-text))) "")};
 
 /// <summary>
 /// ${3:Description}
@@ -14,9 +14,9 @@ private $1 ${2:$(if (> (length text) 0) (format "_%s%s" (downcase (substring tex
 public ${1:Type} ${2:Name}
 {
     get {
-        return this.${2:$(if (> (length text) 0) (format "_%s%s" (downcase (substring text 0 1)) (substring text 1 (length text))) "")};
+        return this.${2:$(if (> (length yas-text) 0) (format "_%s%s" (downcase (substring yas-text 0 1)) (substring yas-text 1 (length yas-text))) "")};
     }
     set {
-        this.${2:$(if (> (length text) 0) (format "_%s%s" (downcase (substring text 0 1)) (substring text 1 (length text))) "")} = value;
+        this.${2:$(if (> (length yas-text) 0) (format "_%s%s" (downcase (substring yas-text 0 1)) (substring yas-text 1 (length yas-text))) "")} = value;
     }
 }

--- a/csharp-mode/method
+++ b/csharp-mode/method
@@ -4,7 +4,7 @@
 # --
 /// <summary>
 /// ${5:Description}
-/// </summary>${2:$(if (string= (upcase text) "VOID") "" (format "%s%s%s" "\n/// <returns><c>" text "</c></returns>"))}
+/// </summary>${2:$(if (string= (upcase yas-text) "VOID") "" (format "%s%s%s" "\n/// <returns><c>" yas-text "</c></returns>"))}
 ${1:public} ${2:void} ${3:MethodName}($4)
 {
 $0

--- a/latex-mode/acronym
+++ b/latex-mode/acronym
@@ -2,4 +2,4 @@
 # name: acronym
 # key: ac
 # --
-\newacronym{${1:label}}{${1:$(upcase text)}}{${2:Name}}
+\newacronym{${1:label}}{${1:$(upcase yas-text)}}{${2:Name}}


### PR DESCRIPTION
I used this command, then picked out the parts that didn't seem like matches. It may need tweaking

```
 find . -type f -exec grep -l '# --' {} \; | xargs sed -i -e 's/\([\t\n ]\)text/\1yas-text/g'
```
