### PR TITLE
fix top level Java class snippet

### DIFF
--- a/java-mode/file_class
+++ b/java-mode/file_class
@@ -2,10 +2,8 @@
 # name: file_class
 # key: file
 # --
-public class ${1:`(let ((fn (file-name-nondirectory
-                            (file-name-sans-extension
-                                 (or (buffer-file-name)
-                                     (buffer-name (current-buffer))))))))}
-
+public class ${1:`(file-name-base
+                    (or (buffer-file-name)
+                        (buffer-name)))`} {
   $0
-end
+}


### PR DESCRIPTION
I guess it was copied from ruby or something (`end` isn't valid in Java).
