### PR TITLE
-K flag should be dropped now

### DIFF
--- a/ruby-mode/rb
+++ b/ruby-mode/rb
@@ -1,4 +1,4 @@
-#name : /usr/bin/ruby -wKU
+#name : /usr/bin/ruby -wU
 #group : general
 # --
-#!/usr/bin/ruby -wKU
+#!/usr/bin/ruby -wU


### PR DESCRIPTION
When I create an executable ruby script with -K option and run it, I get the following warning.

/usr/bin/ruby: warning: -K is specified; it is for 1.8 compatibility and may cause odd behavior

I am using ruby 2.1.2p95
