### PR TITLE
keep indentation of 4 for python snippets

### DIFF
--- a/python-mode/assertRaises.with
+++ b/python-mode/assertRaises.with
@@ -3,4 +3,4 @@
 # key: ar
 # --
 with self.assertRaises(${1:Exception}):
-     $0
+    $0

--- a/python-mode/cls
+++ b/python-mode/cls
@@ -4,4 +4,4 @@
 # group: object oriented
 # --
 class ${1:class}:
-      $0
+    $0

--- a/python-mode/if
+++ b/python-mode/if
@@ -4,4 +4,4 @@
 # group : control structure
 # --
 if ${1:cond}:
-   $0
+    $0

--- a/python-mode/ife
+++ b/python-mode/ife
@@ -4,6 +4,6 @@
 # group : control structure
 # --
 if $1:
-   $2
+    $2
 else:
-   $0
+    $0

--- a/python-mode/ifmain
+++ b/python-mode/ifmain
@@ -3,4 +3,4 @@
 # key: ifm
 # --
 if __name__ == '__main__':
-   ${1:main()}
+    ${1:main()}

--- a/python-mode/prop
+++ b/python-mode/prop
@@ -2,16 +2,16 @@
 # name: prop
 # --
 def ${1:foo}():
-   doc = """${2:Doc string}"""
-   def fget(self):
-       return self._$1
+    doc = """${2:Doc string}"""
+    def fget(self):
+        return self._$1
 
-   def fset(self, value):
-       self._$1 = value
+    def fset(self, value):
+        self._$1 = value
 
-   def fdel(self):
-       del self._$1
-   return locals()
+    def fdel(self):
+        del self._$1
+    return locals()
 $1 = property(**$1())
 
 $0

--- a/python-mode/script
+++ b/python-mode/script
@@ -5,7 +5,7 @@
 #!/usr/bin/env python
 
 def main():
-   pass
+    pass
 
 if __name__ == '__main__':
-   main()
+    main()

--- a/python-mode/test_class
+++ b/python-mode/test_class
@@ -4,4 +4,4 @@
 # group : testing
 # --
 class Test${1:toTest}(${2:unittest.TestCase}):
-      $0
+    $0

--- a/python-mode/while
+++ b/python-mode/while
@@ -4,4 +4,4 @@
 # group: control structure
 # --
 while ${1:True}:
-      $0
+    $0

--- a/python-mode/with
+++ b/python-mode/with
@@ -4,4 +4,4 @@
 # group : control structure
 # --
 with ${1:expr}${2: as ${3:alias}}:
-     $0
+    $0


### PR DESCRIPTION
use 4 spaces in all python snippets indentation. Most of python syntax checker will give a warning for a indentation of 3 spaces.
