### PR TITLE
Update scala/app snippet to extend App

### DIFF
--- a/scala-mode/app
+++ b/scala-mode/app
@@ -1,8 +1,8 @@
 # -*- mode: snippet -*-
 #Author : Anders Bach Nielsen <andersbach.nielsen@epfl.ch>
-#name : object name extends Application
+#name : object name extends App
 # key: app
 # --
-object ${1:name} extends Application {
+object ${1:name} extends App {
   $0
 }


### PR DESCRIPTION
Earlier versions of Scala let its users extend a trait `Application` to
avoid boilerplate when writing a main program. The `Application` trait
was deprecated in Scala 2.9, and replaced by the `App` trait
(`Application` was subsequently removed in Scala 2.11). This commit
replaces `Application` with `App` in the `app` snippet.
