### PR TITLE
c++-mode/fori: improve snippet by using C++11 "auto" keyboard

### DIFF
--- a/c++-mode/fori
+++ b/c++-mode/fori
@@ -2,6 +2,6 @@
 # name: fori
 # key: fori
 # --
-for (${1:iter}=${2:var}.begin(); $1!=$2.end(); ++$1) {
+for (${1:auto }${2:it} = ${3:var}.begin(); $2 != $3.end(); ++$2) {
     $0
 }


### PR DESCRIPTION
Hi João Távora,

I just improved a c++-mode snippet "fori" to use a C++11 keyword "auto". Please let me know if my change is acceptable.

Thank you
