### PR TITLE
Fix meta.http-equiv

### DIFF
--- a/html-mode/meta.http-equiv
+++ b/html-mode/meta.http-equiv
@@ -2,4 +2,4 @@
 #name : <meta http-equiv="..." content="..." />
 #group : meta
 # --
-<meta name="${1:Content-Type}" content="${2:text/html; charset=UTF-8}" />
+<meta http-equiv="${1:Content-Type}" content="${2:text/html; charset=UTF-8}" />


### PR DESCRIPTION
The meta tag in the snippet had the "name" instead of "http-equiv" attribute.
