### PR TITLE
c++-mode/cout: improve

### DIFF
--- a/c++-mode/cout
+++ b/c++-mode/cout
@@ -2,4 +2,4 @@
 # name: cout
 # key: cout
 # --
-std::cout << ${1:string} $0<< std::endl;
+${1:std::}cout << $0${2: << '${3:\n}'};


### PR DESCRIPTION
Hi,

I've improve the "cout" snippet. Below is a copy from the commit message.

Improve this snippet by:
1. Using '\n' instead of "std::endl" to improve the speed of streaming output. Generally, "std::endl" should be used only when absolutely necessary because sending "std::endl" flushes the stream which is an expensive operation.
2. Giving user a chance to decide whether to keep the name space prefix "std::" (type "C-d" to delete the name space prefix).
3. Giving user a chance to decide whether to keep the entire part of " << '\n'". If kept, she can further decided whether to change the '\n' to something else.

York
