### PR TITLE
Merge snippets from atotto for go mode

### DIFF
--- a/go-mode/benchmark
+++ b/go-mode/benchmark
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: benchmark
+# key: bench
+# contributor : @atotto
+# --
+func Benchmark$1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		$0
+	}
+}

--- a/go-mode/error
+++ b/go-mode/error
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: error
+# key: err
+# contributor : @atotto
+# --
+if err != nil {
+	$0
+}

--- a/go-mode/example
+++ b/go-mode/example
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: example
+# key: example
+# contributor : @atotto
+# --
+func Example$1() {
+	$0
+}

--- a/go-mode/forrange
+++ b/go-mode/forrange
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: for range
+# key: range
+# contributor : @atotto
+# --
+for ${3:key}, ${2:value} := range ${1:target} {
+	$0
+}

--- a/go-mode/test
+++ b/go-mode/test
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: test
+# key: at
+# contributor : @atotto
+# --
+func Test$1(t *testing.T) {
+	$0
+}

--- a/go-mode/testmain
+++ b/go-mode/testmain
@@ -1,0 +1,21 @@
+# -*- mode: snippet -*-
+# name: testmain
+# key: testmain
+# contributor : @atotto
+# --
+func TestMain(m *testing.M) {
+	setup()
+	ret := m.Run()
+	if ret == 0 {
+		teardown()
+	}
+	os.Exit(ret)
+}
+
+func setup() {
+	$1
+}
+
+func teardown() {
+	$2
+}


### PR DESCRIPTION
Copy benchmark, error, example, forrange, test, testmain from
https://github.com/atotto/yasnippet-golang. Changed test's key to `at`
to avoid conficts.