### PR TITLE
prog-mode/fixme: disable on sh-mode

### DIFF
--- a/prog-mode/fixme
+++ b/prog-mode/fixme
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: fixme
 # key: fi
+# condition: (not (eq major-mode 'sh-mode))
 # --
 `(yas-with-comment "FIXME: ")`


### PR DESCRIPTION
It's cute the first time you try and close an if<->fi block in a shell
script but after the billionth time you just want it to stop doing that.