### PR TITLE
Added doxygen-mode for cc-mode

### DIFF
--- a/c-mode/fopen
+++ b/c-mode/fopen
@@ -1,4 +1,0 @@
-#name : FILE *fp = fopen(..., ...);
-# key: fopen
-# --
-FILE *${fp} = fopen(${"file"}, "${r}");

--- a/cc-mode/file_description
+++ b/cc-mode/file_description
@@ -1,0 +1,13 @@
+# -*- mode: snippet -*-
+#cotributor: Henrique Jung <henriquenj@gmail.com>
+#name: File description
+#key: \file
+#group: doxygen
+# --
+/**
+ *   \file ${1:`(file-name-nondirectory(buffer-file-name))`}
+ *   \brief ${2:A Documented file.}
+ ${3:*
+ *  ${4:Detailed description}
+ *
+}*/

--- a/cc-mode/function_description
+++ b/cc-mode/function_description
@@ -1,0 +1,14 @@
+# -*- mode: snippet -*-
+#cotributor: Henrique Jung <henriquenj@gmail.com>
+#name: Function description
+#key: \brief
+#group: doxygen
+# --
+/**
+ *  \brief ${1:function description}
+ ${2:*
+ *  ${3:Detailed description}
+ *
+ }*  \param ${4:param}
+ *  \return ${5:return type}
+ */

--- a/cc-mode/member_description
+++ b/cc-mode/member_description
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+#cotributor: Henrique Jung <henriquenj@gmail.com>
+#name: Member description
+#key: !<
+#group: doxygen
+# --
+/*!< ${1:Detailed description after the member} */


### PR DESCRIPTION
Resubmitting without the merge commits (thanks to @npostavs )

This pull request adds three new snippets for doxygen-like documentation following the manual available at http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html. It also fix fopen snippet which was repeated on two modes.

Comments are welcome.