### PR TITLE
c++-mode/cout: surround `\n' with double quote

### DIFF
--- a/c++-mode/cout
+++ b/c++-mode/cout
@@ -5,4 +5,4 @@
 # --
 `(progn (save-excursion) (goto-char (point-min)) (unless (re-search-forward
 "^using\\s-+namespace std;" nil 'no-errer) "std::"))
-`cout << $0${1: << '${2:\n}'};
+`cout << $0${1: << "${2:\n}"};


### PR DESCRIPTION
Surround `\n` with double quote instead of single quote to make it more flexible to change later. For example, if later one decide to to add more text before the `\n`, he/she can simply add the text without having to change the single quote to double quote.