### PR TITLE
Installation instruction type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Otherwise if you want the latest and greatest snippets collection proceed as fol
 
 1. clone this repository
 2. add to your .emacs the following
-   - `(add-to-list 'yas-root-directory "$DIRECTORY_WHERE_YOU_CLONED")`
+   - `(add-to-list 'yas/root-directory "$DIRECTORY_WHERE_YOU_CLONED")`
    - `(yas-initialize)`
 
 3. `M-x yas-reload-all` to activate them


### PR DESCRIPTION
The README requests that you use the non existent yas-root-directory, instead of the actual yas/root-directory. Changed character to / from - to save others an hour of head scratching.