### PR TITLE
Add `clean` snippet to makefile-gmake-mode

### DIFF
--- a/makefile-gmake-mode/abspath
+++ b/makefile-gmake-mode/abspath
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: abspath
+# contributor: gbalats
+# key: abs
+# --
+\$(abspath ${1:\$(${2:paths})})$0

--- a/makefile-gmake-mode/addprefix
+++ b/makefile-gmake-mode/addprefix
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: addprefix
+# contributor: gbalats
+# key: ap
+# --
+\$(addprefix ${1:\$(${2:dir})/},${3:\$(${4:items})})$0

--- a/makefile-gmake-mode/addsuffix
+++ b/makefile-gmake-mode/addsuffix
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: addsuffix
+# contributor: gbalats
+# key: as
+# --
+\$(addsuffix ${1:.suffix},${2:\$(${3:items})})$0

--- a/makefile-gmake-mode/clean
+++ b/makefile-gmake-mode/clean
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: clean
+# contributor: gbalats
+# expand-env: ((yas-indent-line 'fixed))
+# key: cl
+# --
+clean:
+	${1:rm -r ${2:\$(${outdir})}}
+$0

--- a/makefile-gmake-mode/clean
+++ b/makefile-gmake-mode/clean
@@ -5,5 +5,5 @@
 # key: cl
 # --
 clean:
-	${1:rm -r ${2:\$(${outdir})}}
+	${1:rm -r ${2:\$(${3:outdir})}}
 $0

--- a/makefile-gmake-mode/dir
+++ b/makefile-gmake-mode/dir
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: dir
+# contributor: gbalats
+# key: d
+# --
+\$(dir ${1:\$(${2:paths})})$0

--- a/makefile-gmake-mode/make
+++ b/makefile-gmake-mode/make
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: make
+# contributor: gbalats
+# key: make
+# --
+\$(MAKE) --directory=${1:\$@}
+$0

--- a/makefile-gmake-mode/notdir
+++ b/makefile-gmake-mode/notdir
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: notdir
+# contributor: gbalats
+# key: nd
+# --
+\$(notdir ${1:\$(${2:paths})})$0

--- a/makefile-gmake-mode/shell
+++ b/makefile-gmake-mode/shell
@@ -1,0 +1,5 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: shell
+# key: sh
+# --
+\$(shell ${1:command})$0

--- a/makefile-gmake-mode/special
+++ b/makefile-gmake-mode/special
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: special targets
+# contributor: gbalats
+# key: .
+# --
+.${1:PHONY$(upcase yas-text)}: $0

--- a/makefile-gmake-mode/template
+++ b/makefile-gmake-mode/template
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: template
+# contributor: gbalats
+# binding: C-c C-t
+# --
+define ${1:PROGRAM$(upcase yas-text)}_template
+$0
+endef
+
+\$(foreach ${2:${1:$(downcase yas-text)}},\$(${3:$1S}),\$(eval \$(call $1_template,\$($2))))

--- a/makefile-mode/clean
+++ b/makefile-mode/clean
@@ -5,5 +5,5 @@
 # key: cl
 # --
 clean:
-	${1:rm -r ${2:\$(${3:outdir})}}
+	${1:rm -r ${2:\$(${3:OUTDIR})}}
 $0


### PR DESCRIPTION
Adding some snippets for `makefile-gmake-mode`:
* common functions (mostly about filesystem paths)
* a typical clean target
* a template definition (and generation).

Since the typical case (and the one worth to simplify by using yasnippet) is to have variable operands (e.g., `$(var)`), I used nested placeholder fields extensively to cover all cases (so that you only have to type `var` or skip the variable altogether and type in a constant instead).