### PR TITLE
added include-guard for c++-mode

### DIFF
--- a/c++-mode/include-guard
+++ b/c++-mode/include-guard
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: include-guard
+# key: ig
+# --
+#ifndef ${1:`(upcase (file-name-nondirectory (directory-file-name (file-name-directory (buffer-file-name)))))`_`(upcase (file-name-nondirectory (file-name-sans-extension (buffer-file-name))))`_`(upcase (file-name-extension (buffer-file-name)))`}
+#define $1
+
+$0
+
+#endif /* $1 */


### PR DESCRIPTION
I didn't find any snippet for include guards in c++-mode
For a header file named `<some-path>/include/package/header.extension`, this will expand `ig` to
```
#ifndef PACKAGE_HEADER_EXTENSION
#define PACKAGE_HEADER_EXTENSION

$0

#endif /* PACKAGE_HEADER_EXTENSION */
```

with `$0` being the cursor position.