### PR TITLE
Remove extraneous spaces at the end of common elisp snippets

### DIFF
--- a/emacs-lisp-mode/append
+++ b/emacs-lisp-mode/append
@@ -2,4 +2,4 @@
 #name: append
 #key: append
 # --
-(append $0 )
+(append $0)

--- a/emacs-lisp-mode/apply
+++ b/emacs-lisp-mode/apply
@@ -2,4 +2,4 @@
 #name: apply
 #key: apply
 # --
-(apply $0 )
+(apply $0)

--- a/emacs-lisp-mode/condition-case
+++ b/emacs-lisp-mode/condition-case
@@ -3,4 +3,4 @@
 #key: condition-case
 #key: cc
 # --
-(condition-case $0 )
+(condition-case $0)

--- a/emacs-lisp-mode/consp
+++ b/emacs-lisp-mode/consp
@@ -2,4 +2,4 @@
 #name: consp
 #key: consp
 # --
-(consp $0 )
+(consp $0)

--- a/emacs-lisp-mode/defsubst
+++ b/emacs-lisp-mode/defsubst
@@ -2,4 +2,4 @@
 #name: defsubst
 #key: defsubst
 # --
-(defsubst $0 )
+(defsubst $0)

--- a/emacs-lisp-mode/delete-region
+++ b/emacs-lisp-mode/delete-region
@@ -3,4 +3,4 @@
 #key: delete-region
 #key: dr
 # --
-(delete-region $0 )
+(delete-region $0)

--- a/emacs-lisp-mode/dolist
+++ b/emacs-lisp-mode/dolist
@@ -2,4 +2,4 @@
 #name: dolist
 #key: dolist
 # --
-(dolist $0 )
+(dolist $0)

--- a/emacs-lisp-mode/expand-file-name
+++ b/emacs-lisp-mode/expand-file-name
@@ -3,4 +3,4 @@
 #key: expand-file-name
 #key: efn
 # --
-(expand-file-name $0 )
+(expand-file-name $0)

--- a/emacs-lisp-mode/fboundp
+++ b/emacs-lisp-mode/fboundp
@@ -2,4 +2,4 @@
 #name: fboundp
 #key: fboundp
 # --
-(fboundp '$0 )
+(fboundp '$0)

--- a/emacs-lisp-mode/file-name-nondirectory
+++ b/emacs-lisp-mode/file-name-nondirectory
@@ -3,4 +3,4 @@
 #key: file-name-nondirectory
 #key: fnn
 # --
-(file-name-nondirectory $0 )
+(file-name-nondirectory $0)

--- a/emacs-lisp-mode/file-relative-name
+++ b/emacs-lisp-mode/file-relative-name
@@ -3,4 +3,4 @@
 #key: file-relative-name
 #key: frn
 # --
-(file-relative-name $0 )
+(file-relative-name $0)

--- a/emacs-lisp-mode/file.read-lines
+++ b/emacs-lisp-mode/file.read-lines
@@ -6,11 +6,11 @@
   (with-temp-buffer
     (insert-file-contents filePath)
     (split-string
-     (buffer-string) "\n" t)) )
+     (buffer-string) "\n" t)))
 
 ;; process all lines
-(mapc 
- (lambda (aLine) 
+(mapc
+ (lambda (aLine)
    (message aLine) ; do your stuff here
    )
  (read-lines "inputFilePath")

--- a/emacs-lisp-mode/find-file
+++ b/emacs-lisp-mode/find-file
@@ -3,4 +3,4 @@
 #key: find-file
 #key: ff
 # --
-(find-file $0 )
+(find-file $0)

--- a/emacs-lisp-mode/forward-line
+++ b/emacs-lisp-mode/forward-line
@@ -3,4 +3,4 @@
 #key: forward-line
 #key: fl
 # --
-(forward-line $0 )
+(forward-line $0)

--- a/emacs-lisp-mode/function
+++ b/emacs-lisp-mode/function
@@ -2,4 +2,4 @@
 #name: function
 #key: function
 # --
-(function $0 )
+(function $0)

--- a/emacs-lisp-mode/let
+++ b/emacs-lisp-mode/let
@@ -3,6 +3,6 @@
 #key: let
 #key: l
 # --
-(let ($1 )
+(let ($1)
  $0
 )

--- a/emacs-lisp-mode/mapcar
+++ b/emacs-lisp-mode/mapcar
@@ -2,4 +2,4 @@
 #name: mapcar
 #key: mapcar
 # --
-(mapcar $0 )
+(mapcar $0)

--- a/emacs-lisp-mode/match-string
+++ b/emacs-lisp-mode/match-string
@@ -3,4 +3,4 @@
 #key: match-string
 #key: ms
 # --
-(match-string $0 )
+(match-string $0)

--- a/emacs-lisp-mode/not
+++ b/emacs-lisp-mode/not
@@ -3,4 +3,4 @@
 #key: not
 #key: n
 # --
-(not $0 )
+(not $0)

--- a/emacs-lisp-mode/or
+++ b/emacs-lisp-mode/or
@@ -3,4 +3,4 @@
 #key: or
 #key: o
 # --
-(or $0 )
+(or $0)

--- a/emacs-lisp-mode/push
+++ b/emacs-lisp-mode/push
@@ -2,4 +2,4 @@
 #name: push
 #key: push
 # --
-(push $0 )
+(push $0)

--- a/emacs-lisp-mode/repeat
+++ b/emacs-lisp-mode/repeat
@@ -2,4 +2,4 @@
 #name: repeat
 #key: repeat
 # --
-(repeat $0 )
+(repeat $0)

--- a/emacs-lisp-mode/require
+++ b/emacs-lisp-mode/require
@@ -2,4 +2,4 @@
 #name: require
 #key: require
 # --
-(require $0 )
+(require $0)

--- a/emacs-lisp-mode/set
+++ b/emacs-lisp-mode/set
@@ -2,4 +2,4 @@
 #name: set
 #key: set
 # --
-(set $0 )
+(set $0)

--- a/emacs-lisp-mode/set-buffer
+++ b/emacs-lisp-mode/set-buffer
@@ -3,4 +3,4 @@
 #key: set-buffer
 #key: sb
 # --
-(set-buffer $0 )
+(set-buffer $0)

--- a/emacs-lisp-mode/setq
+++ b/emacs-lisp-mode/setq
@@ -3,4 +3,4 @@
 #key: setq
 #key: s
 # --
-(setq $0 )
+(setq $0)

--- a/emacs-lisp-mode/string
+++ b/emacs-lisp-mode/string
@@ -2,4 +2,4 @@
 #name: string
 #key: string
 # --
-(string $0 )
+(string $0)

--- a/emacs-lisp-mode/string=
+++ b/emacs-lisp-mode/string=
@@ -2,4 +2,4 @@
 #name: string=
 #key: string=
 # --
-(string= $0 )
+(string= $0)

--- a/emacs-lisp-mode/widget-get
+++ b/emacs-lisp-mode/widget-get
@@ -3,4 +3,4 @@
 #key: widget-get
 #key: wg
 # --
-(widget-get $0 )
+(widget-get $0)

--- a/emacs-lisp-mode/with-current-buffer
+++ b/emacs-lisp-mode/with-current-buffer
@@ -3,4 +3,4 @@
 #key: with-current-buffer
 #key: wcb
 # --
-(with-current-buffer $0 )
+(with-current-buffer $0)

--- a/emacs-lisp-mode/x-file.read-lines
+++ b/emacs-lisp-mode/x-file.read-lines
@@ -7,11 +7,11 @@
   (with-temp-buffer
     (insert-file-contents filePath)
     (split-string
-     (buffer-string) "\n" t)) )
+     (buffer-string) "\n" t)))
 
 ;; process all lines
-(mapc 
- (lambda (aLine) 
+(mapc
+ (lambda (aLine)
    (message aLine) ; do your stuff here
    )
  (read-lines "inputFilePath")


### PR DESCRIPTION
I find myself using lots of these, but I always have to edit them to
remove the extra space they add. This patch removes all of those cases.