### PR TITLE
Ruby: Replace all file-name underscores when creating module name.

### DIFF
--- a/ruby-mode/mod
+++ b/ruby-mode/mod
@@ -6,8 +6,8 @@ module ${1:`(let ((fn (capitalize (file-name-nondirectory
                                  (file-name-sans-extension
          (or (buffer-file-name)
              (buffer-name (current-buffer))))))))
-           (cond
-             ((string-match "_" fn) (replace-match "" nil nil fn))
-              (t fn)))`}
+           (while (string-match "_" fn)
+             (setq fn (replace-match "" nil nil fn)))
+           fn)`}
   $0
 end


### PR DESCRIPTION
The previous implementation replaced only the first.