### PR TITLE
latex: added documentclass and moderncv snippets

### DIFF
--- a/latex-mode/documentclass
+++ b/latex-mode/documentclass
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: documentclass
+# key: doc
+# --
+\documentclass[${1:options}]{$2}
+$0

--- a/latex-mode/moderncv-cvcomputer
+++ b/latex-mode/moderncv-cvcomputer
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: moderncv-cvcomputer
+# key: cvcomp
+# --
+\cvcomputer{${1:category}}{${2:programs}}{${3:category}}{${3:programs}}
+$0

--- a/latex-mode/moderncv-cventry
+++ b/latex-mode/moderncv-cventry
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: moderncv-cventry
+# key: cventry
+# --
+\cventry{${1:year}}{${2:job}}{${3:employer}}{${4:city}}{${5:description}}
+$0

--- a/latex-mode/moderncv-cvlanguage
+++ b/latex-mode/moderncv-cvlanguage
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: moderncv-cvlanguage
+# key: cvlang
+# --
+\cvlanguage{${1:language}}{${2:skill-level}}{${3:comment}}
+$0

--- a/latex-mode/moderncv-cvline
+++ b/latex-mode/moderncv-cvline
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: moderncv-cvline
+# key: cvline
+# --
+\cvline{${1:hobby}}{${2:Description}}
+$0

--- a/latex-mode/moderncv-cvlistdoubleitem
+++ b/latex-mode/moderncv-cvlistdoubleitem
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: moderncv-cvlistdoubleitem
+# key: cvditem
+# --
+\cvlistdoubleitem{${1:item}}{${2:item}}
+$0

--- a/latex-mode/moderncv-cvlistitem
+++ b/latex-mode/moderncv-cvlistitem
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: moderncv-cvlistitem
+# key: cvitem
+# --
+\cvlistitem{${1:item}}
+$0


### PR DESCRIPTION
Snippet(s) for:

* **\documentclass** was missing, which is valuable because it is included in every LaTeX document.

* **moderncv commands** are also a valuable contributions IMHO, because e.g. `\cventry` has 5 Bracket pairs, which exact number i forget frequently.