### PR TITLE
Add snippet for C++11 classes

### DIFF
--- a/c++-mode/.yas-setup.el
+++ b/c++-mode/.yas-setup.el
@@ -1,0 +1,10 @@
+(defun yas-c++-class-name (str)
+  "Search for a class name like `DerivedClass' in STR
+(which may look like `DerivedClass : ParentClass1, ParentClass2, ...')
+
+If found, the class name is returned, otherwise STR is returned"
+  (yas-substr str "[^: ]*"))
+
+(defun yas-c++-class-method-declare-choice ()
+  "Choose and return the end of a C++11 class method declaration"
+  (yas-choose-value '(";" " = default;" " = delete;")))

--- a/c++-mode/class11
+++ b/c++-mode/class11
@@ -7,8 +7,7 @@
 # desc: Snippet for C++11 classes based on c++-mode/class. Allows for Rule of
 # [0, All]. A choice between ";", " = default;", and " = delete;" is presented
 # for each method. The methods and some of the optional keywords/specifiers are
-# exposed as fields that users can easily skip-and-clear. Note that the single
-# vs. differentiated copy/move assignment operators conflict.
+# exposed as fields that users can easily skip-and-clear.
 # Hackish query-replace-regexp to renumber non-mirror fields in the region
 # between public and protected (can use N as a field number in the snippet):
 # \${[0-9N]*:\([^\$]\) -> ${\,(+ 2 \#):\1
@@ -35,20 +34,8 @@ ${2:  //! Default constructor
 }${13:  //! Copy assignment operator
   ${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${14:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
-}${15:  //! Copy assignment operator (lvalue *this)
-  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other) &${16:;$(yas-choose-value '(";" " = default;" " = delete;"))}
-
-}${17:  //! Copy assignment operator (rvalue *this)
-  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other) &&${18:;$(yas-choose-value '(";" " = default;" " = delete;"))}
-
-}${19:  //! Move assignment operator
-  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other)${20: noexcept}${21:;$(yas-choose-value '(";" " = default;" " = delete;"))}
-
-}${22:  //! Move assignment operator (lvalue *this)
-  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other) &${23: noexcept}${24:;$(yas-choose-value '(";" " = default;" " = delete;"))}
-
-}${25:  //! Move assignment operator (rvalue *this)
-  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other) &&${26: noexcept}${27:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+}${15:  //! Move assignment operator
+  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other)${16: noexcept}${17:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
 }$0
 

--- a/c++-mode/class11
+++ b/c++-mode/class11
@@ -1,0 +1,56 @@
+# -*- mode: snippet -*-
+# name: class11
+# key: cls11
+# uuid: d7c41f87-9b8a-479d-bb12-89f4cbdd46a7
+# contributor: Ved Vyas
+# desc: Snippet for C++11 classes based on c++-mode/class. Allows for Rule of
+# [0, All]. A choice between ";", " = default;", and " = delete;" is presented
+# for each method. The methods and some of the optional keywords/specifiers are
+# exposed as fields that users can easily skip-and-clear. Note that the single
+# vs. differentiated copy/move assignment operators conflict.
+# Hackish query-replace-regexp to renumber non-mirror fields in the region
+# between public and protected:
+# \${[0-9N]*:\([^\$]\) -> ${\,(+ 2 \#):\1)
+# References:
+# 1. http://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_five
+# 2. https://en.wikipedia.org/wiki/Rule_of_three_%28C%2B%2B_programming%29#Example_in_C.2B.2B
+# 3. http://stackoverflow.com/a/4782927
+# --
+class ${1:Name}
+{
+public:
+${2:  //! Default constructor
+  ${1:$(yas/substr yas-text "[^: ]*")}()${3:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${4:  //! Copy constructor
+  ${1:$(yas/substr yas-text "[^: ]*")}(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${5:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${6:  //! Move constructor
+  ${1:$(yas/substr yas-text "[^: ]*")}(${1:$(yas/substr yas-text "[^: ]*")} &&other)${7: noexcept}${8:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${9:  //! Destructor
+  ${10:virtual }~${1:$(yas/substr yas-text "[^: ]*")}()${11: noexcept}${12:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${13:  //! Copy assignment operator
+  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${14:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${15:  //! Copy assignment operator (lvalue *this)
+  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other) &${16:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${17:  //! Copy assignment operator (rvalue *this)
+  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other) &&${18:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${19:  //! Move assignment operator
+  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other)${20: noexcept}${21:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${22:  //! Move assignment operator (lvalue *this)
+  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other) &${23: noexcept}${24:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}${25:  //! Move assignment operator (rvalue *this)
+  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other) &&${26: noexcept}${27:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+
+}$0
+
+protected:
+private:
+};

--- a/c++-mode/class11
+++ b/c++-mode/class11
@@ -10,8 +10,8 @@
 # exposed as fields that users can easily skip-and-clear. Note that the single
 # vs. differentiated copy/move assignment operators conflict.
 # Hackish query-replace-regexp to renumber non-mirror fields in the region
-# between public and protected:
-# \${[0-9N]*:\([^\$]\) -> ${\,(+ 2 \#):\1)
+# between public and protected (can use N as a field number in the snippet):
+# \${[0-9N]*:\([^\$]\) -> ${\,(+ 2 \#):\1
 # References:
 # 1. http://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_five
 # 2. https://en.wikipedia.org/wiki/Rule_of_three_%28C%2B%2B_programming%29#Example_in_C.2B.2B

--- a/c++-mode/class11
+++ b/c++-mode/class11
@@ -20,22 +20,22 @@ class ${1:Name}
 {
 public:
 ${2:  ${3://! Default constructor
-  }${1:$(yas/substr yas-text "[^: ]*")}()${4:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+  }${1:$(yas-c++-class-name yas-text)}()${4:;$(yas-c++-class-method-declare-choice)}
 
 }${5:  ${6://! Copy constructor
-  }${1:$(yas/substr yas-text "[^: ]*")}(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${7:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+  }${1:$(yas-c++-class-name yas-text)}(const ${1:$(yas-c++-class-name yas-text)} &other)${7:;$(yas-c++-class-method-declare-choice)}
 
 }${8:  ${9://! Move constructor
-  }${1:$(yas/substr yas-text "[^: ]*")}(${1:$(yas/substr yas-text "[^: ]*")} &&other)${10: noexcept}${11:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+  }${1:$(yas-c++-class-name yas-text)}(${1:$(yas-c++-class-name yas-text)} &&other)${10: noexcept}${11:;$(yas-c++-class-method-declare-choice)}
 
 }${12:  ${13://! Destructor
-  }${14:virtual }~${1:$(yas/substr yas-text "[^: ]*")}()${15: noexcept}${16:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+  }${14:virtual }~${1:$(yas-c++-class-name yas-text)}()${15: noexcept}${16:;$(yas-c++-class-method-declare-choice)}
 
 }${17:  ${18://! Copy assignment operator
-  }${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${19:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+  }${1:$(yas-c++-class-name yas-text)}& operator=(const ${1:$(yas-c++-class-name yas-text)} &other)${19:;$(yas-c++-class-method-declare-choice)}
 
 }${20:  ${21://! Move assignment operator
-  }${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other)${22: noexcept}${23:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+  }${1:$(yas-c++-class-name yas-text)}& operator=(${1:$(yas-c++-class-name yas-text)} &&other)${22: noexcept}${23:;$(yas-c++-class-method-declare-choice)}
 
 }$0
 

--- a/c++-mode/class11
+++ b/c++-mode/class11
@@ -1,6 +1,7 @@
 # -*- mode: snippet -*-
 # name: class11
 # key: cls11
+# group: c++11
 # uuid: d7c41f87-9b8a-479d-bb12-89f4cbdd46a7
 # contributor: Ved Vyas
 # desc: Snippet for C++11 classes based on c++-mode/class. Allows for Rule of

--- a/c++-mode/class11
+++ b/c++-mode/class11
@@ -19,23 +19,23 @@
 class ${1:Name}
 {
 public:
-${2:  //! Default constructor
-  ${1:$(yas/substr yas-text "[^: ]*")}()${3:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+${2:  ${3://! Default constructor
+  }${1:$(yas/substr yas-text "[^: ]*")}()${4:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
-}${4:  //! Copy constructor
-  ${1:$(yas/substr yas-text "[^: ]*")}(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${5:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+}${5:  ${6://! Copy constructor
+  }${1:$(yas/substr yas-text "[^: ]*")}(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${7:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
-}${6:  //! Move constructor
-  ${1:$(yas/substr yas-text "[^: ]*")}(${1:$(yas/substr yas-text "[^: ]*")} &&other)${7: noexcept}${8:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+}${8:  ${9://! Move constructor
+  }${1:$(yas/substr yas-text "[^: ]*")}(${1:$(yas/substr yas-text "[^: ]*")} &&other)${10: noexcept}${11:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
-}${9:  //! Destructor
-  ${10:virtual }~${1:$(yas/substr yas-text "[^: ]*")}()${11: noexcept}${12:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+}${12:  ${13://! Destructor
+  }${14:virtual }~${1:$(yas/substr yas-text "[^: ]*")}()${15: noexcept}${16:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
-}${13:  //! Copy assignment operator
-  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${14:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+}${17:  ${18://! Copy assignment operator
+  }${1:$(yas/substr yas-text "[^: ]*")}& operator=(const ${1:$(yas/substr yas-text "[^: ]*")} &other)${19:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
-}${15:  //! Move assignment operator
-  ${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other)${16: noexcept}${17:;$(yas-choose-value '(";" " = default;" " = delete;"))}
+}${20:  ${21://! Move assignment operator
+  }${1:$(yas/substr yas-text "[^: ]*")}& operator=(${1:$(yas/substr yas-text "[^: ]*")} &&other)${22: noexcept}${23:;$(yas-choose-value '(";" " = default;" " = delete;"))}
 
 }$0
 


### PR DESCRIPTION
Based on c++-mode/class. Allows for Rule of [0, All]. A choice between ";", " = default;", and " = delete;" is presented for each method. The methods and some of the optional keywords/specifiers are  exposed as fields that users can easily skip-and-clear.

References:
1. http://en.cppreference.com/w/cpp/language/rule_of_three#Rule_of_five
2. https://en.wikipedia.org/wiki/Rule_of_three_%28C%2B%2B_programming%29#Example_in_C.2B.2B
3. http://stackoverflow.com/a/4782927