### PR TITLE
Remove compiler warning

### DIFF
--- a/python-mode/.yas-setup.el
+++ b/python-mode/.yas-setup.el
@@ -1,3 +1,5 @@
+(defvar yas-text)
+
 (defun python-split-args (arg-string)
   "Split a python argument string into ((name, default)..) tuples"
   (mapcar (lambda (x)


### PR DESCRIPTION
Makes sure yas-text is defined during byte compilation.