### PR TITLE
Add org-mode code block snippet.

### DIFF
--- a/org-mode/code
+++ b/org-mode/code
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: code
+# key: code_
+# contributor: Liang Zhou <lzhoucs@gmail.com>
+# --
+#+BEGIN_SRC ${1:lang}
+${2:body}
+#+END_SRC
+$0


### PR DESCRIPTION
See [structure of code blocks](http://orgmode.org/manual/Structure-of-code-blocks.html#Structure-of-code-blocks) for details.

This is supposed to be one of the most commonly used `org-mode` snippets.