### PR TITLE
Avoids warnings when compiling

### DIFF
--- a/c++-mode/.yas-setup.el
+++ b/c++-mode/.yas-setup.el
@@ -1,3 +1,5 @@
+(require 'yasnippet)
+
 (defun yas-c++-class-name (str)
   "Search for a class name like `DerivedClass' in STR
 (which may look like `DerivedClass : ParentClass1, ParentClass2, ...')


### PR DESCRIPTION
I discovered in joaotavora/yasnippet#726 that `c++-mode/.yas-setup.el` is givng a warning when compiled.

```
* c++-mode/.yas-setup.el: Require yasnippet.
```