### PR TITLE
Added algorithm-mnemonics for C++

### DIFF
--- a/c++-mode/acl
+++ b/c++-mode/acl
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: accumulate
 # key: acl
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto sum = std::accumulate(std::begin(${1:container}), std::end($1), 0, [](int total, $2) {
   $3

--- a/c++-mode/acl
+++ b/c++-mode/acl
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: accumulate
+# key: acl
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto sum = std::accumulate(std::begin(${1:container}), std::end($1), 0, [](int total, $2) {
+  $3
+});
+$0

--- a/c++-mode/acm
+++ b/c++-mode/acm
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: accumulate
 # key: acm
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto sum = std::accumulate(std::begin(${1:container}), std::end($1), 0);
 $0

--- a/c++-mode/acm
+++ b/c++-mode/acm
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: accumulate
+# key: acm
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto sum = std::accumulate(std::begin(${1:container}), std::end($1), 0);
+$0

--- a/c++-mode/ajf
+++ b/c++-mode/ajf
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: adjacent_find
 # key: ajf
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::adjacent_find(std::begin(${1:container}), std::end($1));
 if (pos != std::end($1)) {

--- a/c++-mode/ajf
+++ b/c++-mode/ajf
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: adjacent_find
+# key: ajf
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::adjacent_find(std::begin(${1:container}), std::end($1));
+if (pos != std::end($1)) {
+  $2
+}
+$0

--- a/c++-mode/alo
+++ b/c++-mode/alo
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: all_of
 # key: alo
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::all_of(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/alo
+++ b/c++-mode/alo
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: all_of
+# key: alo
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::all_of(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+})) {
+  $4
+}
+$0

--- a/c++-mode/ano
+++ b/c++-mode/ano
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: any_of
+# key: ano
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::any_of(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+})) {
+  $4
+}
+$0

--- a/c++-mode/ano
+++ b/c++-mode/ano
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: any_of
 # key: ano
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::any_of(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/cni
+++ b/c++-mode/cni
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: count_if
 # key: cni
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto n = std::count_if(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/cni
+++ b/c++-mode/cni
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: count_if
+# key: cni
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto n = std::count_if(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+});
+$0

--- a/c++-mode/cnt
+++ b/c++-mode/cnt
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: count
 # key: cnt
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto n = std::count(std::begin(${1:container}), std::end($1), $2);
 $0

--- a/c++-mode/cnt
+++ b/c++-mode/cnt
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: count
+# key: cnt
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto n = std::count(std::begin(${1:container}), std::end($1), $2);
+$0

--- a/c++-mode/cpb
+++ b/c++-mode/cpb
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: copy_backward
+# key: cpb
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::copy_backward(std::begin(${1:container}), std::end($1), std::end($1));
+$0

--- a/c++-mode/cpb
+++ b/c++-mode/cpb
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: copy_backward
 # key: cpb
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::copy_backward(std::begin(${1:container}), std::end($1), std::end($1));
 $0

--- a/c++-mode/cpi
+++ b/c++-mode/cpi
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: copy_if
+# key: cpi
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::copy_if(std::begin(${1:container}), std::end($1), std::begin($2),
+[]($3) {
+  $4
+});
+$0

--- a/c++-mode/cpi
+++ b/c++-mode/cpi
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: copy_if
 # key: cpi
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::copy_if(std::begin(${1:container}), std::end($1), std::begin($2),
 []($3) {

--- a/c++-mode/cpn
+++ b/c++-mode/cpn
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: copy_n
+# key: cpn
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::copy_n(std::begin(${1:container}), $2, std::end($1));
+$0

--- a/c++-mode/cpn
+++ b/c++-mode/cpn
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: copy_n
 # key: cpn
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::copy_n(std::begin(${1:container}), $2, std::end($1));
 $0

--- a/c++-mode/cpy
+++ b/c++-mode/cpy
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: copy
+# key: cpy
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::copy(std::begin(${1:container}), std::end($1), std::begin($2));
+$0

--- a/c++-mode/cpy
+++ b/c++-mode/cpy
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: copy
 # key: cpy
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::copy(std::begin(${1:container}), std::end($1), std::begin($2));
 $0

--- a/c++-mode/eql
+++ b/c++-mode/eql
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: equal
+# key: eql
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::equal(std::begin(${1:container}), std::end($1), std::begin($2))) {
+  $3
+}
+$0

--- a/c++-mode/eql
+++ b/c++-mode/eql
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: equal
 # key: eql
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::equal(std::begin(${1:container}), std::end($1), std::begin($2))) {
   $3

--- a/c++-mode/erm
+++ b/c++-mode/erm
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: remove
+# key: erm
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+${1:container}.erase(std::remove(std::begin($1), std::end($1), $2), std::end($1));
+$0

--- a/c++-mode/erm
+++ b/c++-mode/erm
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: remove
 # key: erm
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 ${1:container}.erase(std::remove(std::begin($1), std::end($1), $2), std::end($1));
 $0

--- a/c++-mode/ffo
+++ b/c++-mode/ffo
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: find_first_of
+# key: ffo
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::find_first_of(std::begin(${1:container}), std::end($1),
+  std::begin($2), std::end($3));
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/ffo
+++ b/c++-mode/ffo
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: find_first_of
 # key: ffo
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::find_first_of(std::begin(${1:container}), std::end($1),
   std::begin($2), std::end($3));

--- a/c++-mode/fil
+++ b/c++-mode/fil
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: fill
+# key: fil
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::fill(std::begin(${1:container}), std::end($1), $2);
+$0

--- a/c++-mode/fil
+++ b/c++-mode/fil
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: fill
 # key: fil
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::fill(std::begin(${1:container}), std::end($1), $2);
 $0

--- a/c++-mode/fin
+++ b/c++-mode/fin
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: find_if_not
 # key: fin
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::find_if_not(std::begin(${1:container}), std::end($1),[]($2) {
   $3

--- a/c++-mode/fin
+++ b/c++-mode/fin
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: find_if_not
+# key: fin
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::find_if_not(std::begin(${1:container}), std::end($1),[]($2) {
+  $3
+});
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/fln
+++ b/c++-mode/fln
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: fill_n
+# key: fln
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::fill_n(std::begin(${1:container}), $2, $3);
+$0

--- a/c++-mode/fln
+++ b/c++-mode/fln
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: fill_n
 # key: fln
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::fill_n(std::begin(${1:container}), $2, $3);
 $0

--- a/c++-mode/fnd
+++ b/c++-mode/fnd
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: find
+# key: fnd
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::find(std::begin(${1:container}), std::end($1), $2);
+if (pos != std::end($1)) {
+  $3
+}
+$0

--- a/c++-mode/fnd
+++ b/c++-mode/fnd
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: find
 # key: fnd
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::find(std::begin(${1:container}), std::end($1), $2);
 if (pos != std::end($1)) {

--- a/c++-mode/fne
+++ b/c++-mode/fne
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: find_end
+# key: fne
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::find_std::end(std::begin(${1:container}), std::end($1),
+  std::begin($2), std::end($3));
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/fne
+++ b/c++-mode/fne
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: find_end
 # key: fne
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::find_std::end(std::begin(${1:container}), std::end($1),
   std::begin($2), std::end($3));

--- a/c++-mode/fni
+++ b/c++-mode/fni
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: find_if
+# key: fni
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::find_if(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+});
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/fni
+++ b/c++-mode/fni
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: find_if
 # key: fni
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::find_if(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/fre
+++ b/c++-mode/fre
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: for_each
+# key: fre
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::for_each(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+});
+$0

--- a/c++-mode/fre
+++ b/c++-mode/fre
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: for_each
 # key: fre
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::for_each(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/gnn
+++ b/c++-mode/gnn
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: generate_n
 # key: gnn
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::generate_n(std::begin(${1:container}), $2, []($3) {
   $4

--- a/c++-mode/gnn
+++ b/c++-mode/gnn
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: generate_n
+# key: gnn
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::generate_n(std::begin(${1:container}), $2, []($3) {
+  $4
+});
+$0

--- a/c++-mode/gnr
+++ b/c++-mode/gnr
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: generate
+# key: gnr
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::generate(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+});
+$0

--- a/c++-mode/gnr
+++ b/c++-mode/gnr
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: generate
 # key: gnr
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::generate(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/ihp
+++ b/c++-mode/ihp
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: is_heap
+# key: ihp
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::is_heap(std::begin(${1:container}), std::end($1))) {
+  $2
+}
+$0

--- a/c++-mode/ihp
+++ b/c++-mode/ihp
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: is_heap
 # key: ihp
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::is_heap(std::begin(${1:container}), std::end($1))) {
   $2

--- a/c++-mode/ihu
+++ b/c++-mode/ihu
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: is_heap_until
 # key: ihu
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::is_heap_until(std::begin(${1:container}), std::end($1));
 if (pos != std::end($1)) {

--- a/c++-mode/ihu
+++ b/c++-mode/ihu
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: is_heap_until
+# key: ihu
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::is_heap_until(std::begin(${1:container}), std::end($1));
+if (pos != std::end($1)) {
+  $2
+}
+$0

--- a/c++-mode/ipr
+++ b/c++-mode/ipr
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: is_permutation
+# key: ipr
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::is_permutation(std::begin(${1:container}), std::end($1), std::begin($2))) {
+  $3
+}
+$0

--- a/c++-mode/ipr
+++ b/c++-mode/ipr
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: is_permutation
 # key: ipr
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::is_permutation(std::begin(${1:container}), std::end($1), std::begin($2))) {
   $3

--- a/c++-mode/ipt
+++ b/c++-mode/ipt
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: is_partitioned
 # key: ipt
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::is_partitioned(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/ipt
+++ b/c++-mode/ipt
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: is_partitioned
+# key: ipt
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::is_partitioned(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+})) {
+  $4
+}
+$0

--- a/c++-mode/iss
+++ b/c++-mode/iss
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: is_sorted
+# key: iss
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::is_sorted(std::begin(${1:container}), std::end($1))) {
+  $2
+}
+$0

--- a/c++-mode/iss
+++ b/c++-mode/iss
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: is_sorted
 # key: iss
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::is_sorted(std::begin(${1:container}), std::end($1))) {
   $2

--- a/c++-mode/isu
+++ b/c++-mode/isu
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: is_sorted_until
+# key: isu
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::is_sorted_until(std::begin(${1:container}), std::end($1));
+if (pos != std::end($1)) {
+  $2
+}
+$0

--- a/c++-mode/isu
+++ b/c++-mode/isu
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: is_sorted_until
 # key: isu
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::is_sorted_until(std::begin(${1:container}), std::end($1));
 if (pos != std::end($1)) {

--- a/c++-mode/ita
+++ b/c++-mode/ita
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: iota
 # key: ita
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::iota(std::begin(${1:container}), std::end($1), $2);
 $0

--- a/c++-mode/ita
+++ b/c++-mode/ita
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: iota
+# key: ita
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::iota(std::begin(${1:container}), std::end($1), $2);
+$0

--- a/c++-mode/ltr
+++ b/c++-mode/ltr
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: transform
+# key: ltr
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+${1:container}.erase(0, $1.find_first_not_of(" \t\n\r"));
+$0

--- a/c++-mode/ltr
+++ b/c++-mode/ltr
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: transform
 # key: ltr
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 ${1:container}.erase(0, $1.find_first_not_of(" \t\n\r"));
 $0

--- a/c++-mode/lwr
+++ b/c++-mode/lwr
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: transform
 # key: lwr
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::transform(std::begin(${1:container}), std::end($1), std::begin($1), [](char c) {
 return std::tolower(c);});

--- a/c++-mode/lwr
+++ b/c++-mode/lwr
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: transform
+# key: lwr
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::transform(std::begin(${1:container}), std::end($1), std::begin($1), [](char c) {
+return std::tolower(c);});
+$0

--- a/c++-mode/lxc
+++ b/c++-mode/lxc
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: lexigraphical_compare
+# key: lxc
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::lexigraphical_compare(std::begin(${1:container}), std::end($1),
+  std::begin($2), std::end($3)) {
+  $4
+}
+$0

--- a/c++-mode/lxc
+++ b/c++-mode/lxc
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: lexigraphical_compare
 # key: lxc
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::lexigraphical_compare(std::begin(${1:container}), std::end($1),
   std::begin($2), std::end($3)) {

--- a/c++-mode/mkh
+++ b/c++-mode/mkh
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: make_heap
 # key: mkh
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::make_heap(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/mkh
+++ b/c++-mode/mkh
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: make_heap
+# key: mkh
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::make_heap(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/mme
+++ b/c++-mode/mme
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: minmax_element
+# key: mme
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto minmax = std::minmax_element(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/mme
+++ b/c++-mode/mme
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: minmax_element
 # key: mme
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto minmax = std::minmax_element(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/mne
+++ b/c++-mode/mne
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: min_element
 # key: mne
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::min_element(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/mne
+++ b/c++-mode/mne
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: min_element
+# key: mne
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::min_element(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/mpb
+++ b/c++-mode/mpb
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: move_backward
 # key: mpb
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::move_backward(std::begin(${1:container}), std::end($1), std::end($1));
 $0

--- a/c++-mode/mpb
+++ b/c++-mode/mpb
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: move_backward
+# key: mpb
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::move_backward(std::begin(${1:container}), std::end($1), std::end($1));
+$0

--- a/c++-mode/mrg
+++ b/c++-mode/mrg
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: merge
 # key: mrg
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::merge(std::begin(${1:container}), std::end($1),
 std::begin($2), std::end($3), std::begin($4));

--- a/c++-mode/mrg
+++ b/c++-mode/mrg
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: merge
+# key: mrg
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::merge(std::begin(${1:container}), std::end($1),
+std::begin($2), std::end($3), std::begin($4));
+$0

--- a/c++-mode/msm
+++ b/c++-mode/msm
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: mismatch
 # key: msm
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto values = std::mismatch(std::begin(${1:container}), std::end($1), std::begin($1));
 if (values.first == std::end($1)) {

--- a/c++-mode/msm
+++ b/c++-mode/msm
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: mismatch
+# key: msm
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto values = std::mismatch(std::begin(${1:container}), std::end($1), std::begin($1));
+if (values.first == std::end($1)) {
+  $2
+} else {
+  $3
+}
+$0

--- a/c++-mode/mxe
+++ b/c++-mode/mxe
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: max_element
 # key: mxe
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::max_element(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/mxe
+++ b/c++-mode/mxe
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: max_element
+# key: mxe
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::max_element(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/nno
+++ b/c++-mode/nno
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: none_of
 # key: nno
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::none_of(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/nno
+++ b/c++-mode/nno
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: none_of
+# key: nno
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::none_of(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+})) {
+  $4
+}
+$0

--- a/c++-mode/nth
+++ b/c++-mode/nth
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: nth_element
+# key: nth
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::nth_element(std::begin(${1:container}), std::end($1), std::end($1));
+$0

--- a/c++-mode/nth
+++ b/c++-mode/nth
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: nth_element
 # key: nth
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::nth_element(std::begin(${1:container}), std::end($1), std::end($1));
 $0

--- a/c++-mode/nxp
+++ b/c++-mode/nxp
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: next_permutation
 # key: nxp
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::next_permutation(std::begin(${1:container}), std::end($1))) {
   $2

--- a/c++-mode/nxp
+++ b/c++-mode/nxp
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: next_permutation
+# key: nxp
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::next_permutation(std::begin(${1:container}), std::end($1))) {
+  $2
+}
+$0

--- a/c++-mode/oit
+++ b/c++-mode/oit
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: copy
+# key: oit
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::copy(std::begin(${1:container}), std::end($1), std::ostream_iterator<$2>{
+%\istd::cout, "$3"
+});
+$0

--- a/c++-mode/oit
+++ b/c++-mode/oit
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: copy
 # key: oit
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::copy(std::begin(${1:container}), std::end($1), std::ostream_iterator<$2>{
 %\istd::cout, "$3"

--- a/c++-mode/phh
+++ b/c++-mode/phh
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: push_heap
 # key: phh
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::push_heap(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/phh
+++ b/c++-mode/phh
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: push_heap
+# key: phh
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::push_heap(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/ppt
+++ b/c++-mode/ppt
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: partition_point
 # key: ppt
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::partition_point(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/ppt
+++ b/c++-mode/ppt
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: partition_point
+# key: ppt
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::partition_point(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+});
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/prp
+++ b/c++-mode/prp
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: prev_permutation
 # key: prp
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 if (std::prev_permutation(std::begin(${1:container}), std::end($1))) {
   $2

--- a/c++-mode/prp
+++ b/c++-mode/prp
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: prev_permutation
+# key: prp
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+if (std::prev_permutation(std::begin(${1:container}), std::end($1))) {
+  $2
+}
+$0

--- a/c++-mode/psc
+++ b/c++-mode/psc
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: partial_sort_copy
+# key: psc
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::partial_sort_copy(std::begin(${1:container}), std::end($1),
+                  std::begin($2), std::end($3));
+$0

--- a/c++-mode/psc
+++ b/c++-mode/psc
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: partial_sort_copy
 # key: psc
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::partial_sort_copy(std::begin(${1:container}), std::end($1),
                   std::begin($2), std::end($3));

--- a/c++-mode/pst
+++ b/c++-mode/pst
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: partial_sort
 # key: pst
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::partial_sort(std::begin(${1:container}), std::end($1), std::end($1));
 $0

--- a/c++-mode/pst
+++ b/c++-mode/pst
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: partial_sort
+# key: pst
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::partial_sort(std::begin(${1:container}), std::end($1), std::end($1));
+$0

--- a/c++-mode/ptc
+++ b/c++-mode/ptc
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: partition_copy
+# key: ptc
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::partition_copy(std::begin(${1:container}), std::end($1),
+                  std::begin($2), std::end($3));
+$0

--- a/c++-mode/ptc
+++ b/c++-mode/ptc
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: partition_copy
 # key: ptc
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::partition_copy(std::begin(${1:container}), std::end($1),
                   std::begin($2), std::end($3));

--- a/c++-mode/ptn
+++ b/c++-mode/ptn
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: partition
+# key: ptn
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::partition(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+});
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/ptn
+++ b/c++-mode/ptn
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: partition
 # key: ptn
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::partition(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/rci
+++ b/c++-mode/rci
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: replace_copy_if
 # key: rci
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::replace_copy_if(std::begin(${1:container}), std::end($1),
   std::begin($1), []($2) {

--- a/c++-mode/rci
+++ b/c++-mode/rci
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: replace_copy_if
+# key: rci
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::replace_copy_if(std::begin(${1:container}), std::end($1),
+  std::begin($1), []($2) {
+  $3
+}, $4);
+$0

--- a/c++-mode/rmc
+++ b/c++-mode/rmc
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: remove_copy
 # key: rmc
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::remove_copy(std::begin(${1:container}), std::end($1),
   std::begin($1), $2);

--- a/c++-mode/rmc
+++ b/c++-mode/rmc
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: remove_copy
+# key: rmc
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::remove_copy(std::begin(${1:container}), std::end($1),
+  std::begin($1), $2);
+$0

--- a/c++-mode/rmf
+++ b/c++-mode/rmf
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: remove_copy_if
 # key: rmf
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::remove_copy_if(std::begin(${1:container}), std::end($1),
   std::begin($1), []($2) {

--- a/c++-mode/rmf
+++ b/c++-mode/rmf
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: remove_copy_if
+# key: rmf
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::remove_copy_if(std::begin(${1:container}), std::end($1),
+  std::begin($1), []($2) {
+    $3
+});
+$0

--- a/c++-mode/rmi
+++ b/c++-mode/rmi
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: remove_if
+# key: rmi
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::remove_if(std::begin(${1:container}), std::end($1), []($2) {
+  $3
+});
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/rmi
+++ b/c++-mode/rmi
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: remove_if
 # key: rmi
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::remove_if(std::begin(${1:container}), std::end($1), []($2) {
   $3

--- a/c++-mode/rmv
+++ b/c++-mode/rmv
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: remove
+# key: rmv
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::remove(std::begin(${1:container}), std::end($1), $2);
+if (pos != std::end($1)) {
+  $3
+}
+$0

--- a/c++-mode/rmv
+++ b/c++-mode/rmv
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: remove
 # key: rmv
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::remove(std::begin(${1:container}), std::end($1), $2);
 if (pos != std::end($1)) {

--- a/c++-mode/rpc
+++ b/c++-mode/rpc
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: replace_copy
 # key: rpc
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::replace_copy(std::begin(${1:container}), std::end($1), std::begin($1), $2, $3);
 $0

--- a/c++-mode/rpc
+++ b/c++-mode/rpc
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: replace_copy
+# key: rpc
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::replace_copy(std::begin(${1:container}), std::end($1), std::begin($1), $2, $3);
+$0

--- a/c++-mode/rpi
+++ b/c++-mode/rpi
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: replace_if
+# key: rpi
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::replace_if(std::begin(${1:container}), std::end($1), []($2) {
+$3
+}, $4);
+$0

--- a/c++-mode/rpi
+++ b/c++-mode/rpi
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: replace_if
 # key: rpi
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::replace_if(std::begin(${1:container}), std::end($1), []($2) {
 $3

--- a/c++-mode/rpl
+++ b/c++-mode/rpl
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: replace
+# key: rpl
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::replace(std::begin(${1:container}), std::end($1), $2, $3);
+$0

--- a/c++-mode/rpl
+++ b/c++-mode/rpl
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: replace
 # key: rpl
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::replace(std::begin(${1:container}), std::end($1), $2, $3);
 $0

--- a/c++-mode/rtc
+++ b/c++-mode/rtc
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: rotate_copy
 # key: rtc
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::rotate_copy(std::begin(${1:container}), std::begin($2), std::end($1),
   std::begin($3));

--- a/c++-mode/rtc
+++ b/c++-mode/rtc
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: rotate_copy
+# key: rtc
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::rotate_copy(std::begin(${1:container}), std::begin($2), std::end($1),
+  std::begin($3));
+$0

--- a/c++-mode/rte
+++ b/c++-mode/rte
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: rotate
+# key: rte
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::rotate(std::begin(${1:container}), std::begin($2), std::end($1));
+$0

--- a/c++-mode/rte
+++ b/c++-mode/rte
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: rotate
 # key: rte
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::rotate(std::begin(${1:container}), std::begin($2), std::end($1));
 $0

--- a/c++-mode/rvc
+++ b/c++-mode/rvc
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: reverse_copy
 # key: rvc
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::reverse_copy(std::begin(${1:container}), std::end($1), std::begin($2));
 $0

--- a/c++-mode/rvc
+++ b/c++-mode/rvc
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: reverse_copy
+# key: rvc
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::reverse_copy(std::begin(${1:container}), std::end($1), std::begin($2));
+$0

--- a/c++-mode/rvr
+++ b/c++-mode/rvr
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: reverse
+# key: rvr
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::reverse(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/rvr
+++ b/c++-mode/rvr
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: reverse
 # key: rvr
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::reverse(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/shf
+++ b/c++-mode/shf
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: random_shuffle
+# key: shf
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::random_shuffle(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/shf
+++ b/c++-mode/shf
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: random_shuffle
 # key: shf
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::random_shuffle(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/spt
+++ b/c++-mode/spt
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: stable_partition
+# key: spt
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::stable_partition(std::begin(${1:container}), std::end($1), []($2) {
+  $3});
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/spt
+++ b/c++-mode/spt
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: stable_partition
 # key: spt
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::stable_partition(std::begin(${1:container}), std::end($1), []($2) {
   $3});

--- a/c++-mode/srh
+++ b/c++-mode/srh
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: search
 # key: srh
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::search(std::begin(${1:container}), std::end($1),
   std::begin($2), std::end($3));

--- a/c++-mode/srh
+++ b/c++-mode/srh
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: search
+# key: srh
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::search(std::begin(${1:container}), std::end($1),
+  std::begin($2), std::end($3));
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/srn
+++ b/c++-mode/srn
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: search_n
 # key: srn
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::search_n(std::begin(${1:container}), std::end($1),$2,$3);
 if (pos != std::end($1)) {

--- a/c++-mode/srn
+++ b/c++-mode/srn
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: search_n
+# key: srn
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::search_n(std::begin(${1:container}), std::end($1),$2,$3);
+if (pos != std::end($1)) {
+  $4
+}
+$0

--- a/c++-mode/srt
+++ b/c++-mode/srt
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: sort
 # key: srt
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::sort(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/srt
+++ b/c++-mode/srt
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: sort
+# key: srt
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::sort(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/sth
+++ b/c++-mode/sth
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: sort_heap
+# key: sth
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::sort_heap(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/sth
+++ b/c++-mode/sth
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: sort_heap
 # key: sth
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::sort_heap(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/sti
+++ b/c++-mode/sti
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: cin
 # key: sti
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::cin >>
 $0

--- a/c++-mode/sti
+++ b/c++-mode/sti
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: cin
+# key: sti
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::cin >>
+$0

--- a/c++-mode/sto
+++ b/c++-mode/sto
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: cout
+# key: sto
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::cout <<
+$0

--- a/c++-mode/sto
+++ b/c++-mode/sto
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: cout
 # key: sto
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::cout <<
 $0

--- a/c++-mode/sts
+++ b/c++-mode/sts
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: stable_sort
+# key: sts
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::stable_sort(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/sts
+++ b/c++-mode/sts
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: stable_sort
 # key: sts
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::stable_sort(std::begin(${1:container}), std::end($1));
 $0

--- a/c++-mode/stv
+++ b/c++-mode/stv
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: vector
 # key: stv
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::vector<$2> $3
 $0

--- a/c++-mode/stv
+++ b/c++-mode/stv
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: vector
+# key: stv
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::vector<$2> $3
+$0

--- a/c++-mode/swr
+++ b/c++-mode/swr
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: swap_ranges
+# key: swr
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::swap_ranges(std::begin(${1:container}), std::end($1), std::begin($2));
+$0

--- a/c++-mode/swr
+++ b/c++-mode/swr
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: swap_ranges
 # key: swr
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::swap_ranges(std::begin(${1:container}), std::end($1), std::begin($2));
 $0

--- a/c++-mode/tfm
+++ b/c++-mode/tfm
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: transform
 # key: tfm
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::transform(std::begin(${1:container}), std::end($1),
   std::begin($1), []($2) {

--- a/c++-mode/tfm
+++ b/c++-mode/tfm
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: transform
+# key: tfm
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::transform(std::begin(${1:container}), std::end($1),
+  std::begin($1), []($2) {
+$3%
+});
+$0

--- a/c++-mode/trm
+++ b/c++-mode/trm
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: generate_n
 # key: trm
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 ${1:container}.erase($1.find_last_not_of(" \t\n\r") + 1);
 $0

--- a/c++-mode/trm
+++ b/c++-mode/trm
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: generate_n
+# key: trm
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+${1:container}.erase($1.find_last_not_of(" \t\n\r") + 1);
+$0

--- a/c++-mode/ucp
+++ b/c++-mode/ucp
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: unique_copy
+# key: ucp
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::unique_copy(std::begin(${1:container}), std::end($1),
+  std::ostream_iterator<string>(std::cout, "\n"));
+$0

--- a/c++-mode/ucp
+++ b/c++-mode/ucp
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: unique_copy
 # key: ucp
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::unique_copy(std::begin(${1:container}), std::end($1),
   std::ostream_iterator<string>(std::cout, "\n"));

--- a/c++-mode/upr
+++ b/c++-mode/upr
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: transform
+# key: upr
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+std::transform(std::begin(${1:container}), std::end($1), std::begin($1), [](char c) {
+return std::toupper(c);
+});
+$2
+$0

--- a/c++-mode/upr
+++ b/c++-mode/upr
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: transform
 # key: upr
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 std::transform(std::begin(${1:container}), std::end($1), std::begin($1), [](char c) {
 return std::toupper(c);

--- a/c++-mode/uqe
+++ b/c++-mode/uqe
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: unique
+# key: uqe
+# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
+# --
+auto pos = std::unique(std::begin(${1:container}), std::end($1));
+$0

--- a/c++-mode/uqe
+++ b/c++-mode/uqe
@@ -1,7 +1,6 @@
 # -*- mode: snippet -*-
 # name: unique
 # key: uqe
-# contributor: Tommy BENNETT and Ludwig PACIFICI <ludwig@lud.cc>
 # --
 auto pos = std::unique(std::begin(${1:container}), std::end($1));
 $0


### PR DESCRIPTION
Hello

Here are some snippets for standard C++ algorithm.  It is a set of abbreviations described in the repository [algorithm-mnemonics](https://github.com/tommybennett/algorithm-mnemonics). I did a port of it (in the repository [algorithm-mnemonics-emacs](https://github.com/ludwigpacifici/algorithm-mnemonics-emacs)) for Yasnippet.

I checked the names via `yas-describe-tables`. I saw no name collision for a buffer with `c++-mode`. The snippets are tested on my machine. Do you require more checks for this pull request?

Thanks