### PR TITLE
Python 'new' snippet uses dict as method argument

### DIFF
--- a/python-mode/__new__
+++ b/python-mode/__new__
@@ -3,6 +3,6 @@
 # key: new
 # group: dunder methods
 # --
-def __new__(mcs, name, bases, dict):
+def __new__(mcs, name, bases, dct):
     $0
-    return type.__new__(mcs, name, bases, dict)
+    return type.__new__(mcs, name, bases, dct)


### PR DESCRIPTION
The python 'new' snippet uses dict as method argument which is a python built-in type.
Using it as a method argument hides the built-in type 'dict' in the method body.