### PR TITLE
Use minimum indentation for python docstring

### DIFF
--- a/python-mode/function_docstring
+++ b/python-mode/function_docstring
@@ -2,9 +2,10 @@
 # name: function_docstring
 # key: fd
 # group: definitions
+# NOTE: Use minimum indentation, because Emacs 25+ doesn't dedent docstrings.
 # --
 def ${1:name}($2):
-    \"\"\"$3
-    ${2:$(python-args-to-docstring)}
-    \"\"\"
-    $0
+ \"\"\"$3
+ ${2:$(python-args-to-docstring)}
+ \"\"\"
+ $0


### PR DESCRIPTION
Fixes joaotavora/yasnippet#750.

```
* python-mode/function_docstring: Reduce indentation to 1, because
Emacs 25+ doesn't dedent docstrings.
```