### PR TITLE
Remove side-effecting expression inside backquotes

### DIFF
--- a/c++-mode/cout
+++ b/c++-mode/cout
@@ -3,6 +3,6 @@
 # name: cout
 # key: cout
 # --
-`(progn (save-excursion) (goto-char (point-min)) (unless (re-search-forward
+`(progn (goto-char (point-min)) (unless (re-search-forward
 "^using\\s-+namespace std;" nil 'no-errer) "std::"))
 `cout << $0${1: << "${2:\n}"};

--- a/cc-mode/case
+++ b/cc-mode/case
@@ -1,8 +1,9 @@
 # -*- mode: snippet -*-
 # name : case : {...}
 # key: case
+# expand-env: ((yas-also-auto-indent-first-line t))
 # --
-`(indent-region (- (point) 20) (+ (point) 20) nil)`case ${2:constexpr}:${3: \{}
+case ${2:constexpr}:${3: \{}
     $0
     break;
 ${3:$(if (string-match "\{" yas-text) "\}" "")}


### PR DESCRIPTION
```
* c++-mode/cout: Remove unneeded `save-excursion'.  Yasnippet already
uses `save-excursion' and the call here had no arguments which made it
a nop.
* cc-mode/case: Indent the first line by binding
`yas-also-auto-indent-first-line' instead of calling `indent-region'.
```

See also http://emacs.stackexchange.com/questions/30977/why-does-indent-region-insert-a-t-into-my-buffer

Actually, the `cout` isn't really a problem, I just happened to see it while searching for other problematic snippets.