### PR TITLE
Added Binding for use-package

### DIFF
--- a/emacs-lisp-mode/use-package
+++ b/emacs-lisp-mode/use-package
@@ -1,0 +1,5 @@
+#contributor: Daniel Hitzel
+#name: use-package
+#key: up
+# --
+(use-package ${1:package-name})

--- a/emacs-lisp-mode/use-package
+++ b/emacs-lisp-mode/use-package
@@ -2,4 +2,5 @@
 #name: use-package
 #key: up
 # --
-(use-package ${1:package-name})
+(use-package ${1:package-name}
+:ensure t$0)

--- a/emacs-lisp-mode/use-package-binding
+++ b/emacs-lisp-mode/use-package-binding
@@ -1,0 +1,5 @@
+#contributor: Daniel Hitzel
+#name: use-package binding
+#key: upb
+# --
+:bind ("${1:binding}" . ${2:function-name})


### PR DESCRIPTION
Hi,

I am using this great package called [use-package](https://github.com/jwiegley/use-package).

About:
use-package allows you to isolate package configuration in your .emacs.

New Binding:
up -> (use-package package-name)
upb -> :bind ("keymap" . function-name)


For Frodo