### PR TITLE
Modifying Python setUp and tearDown methods unittests

### DIFF
--- a/python-mode/test_class
+++ b/python-mode/test_class
@@ -7,16 +7,16 @@ class Test${1:toTest}(${2:unittest.TestCase}):
 
     @classmethod
     def setUpClass(cls):
-        pass
+        ${3:pass}
 
     @classmethod
     def tearDownClass(cls):
-        pass
+        ${4:pass}
 
     def setUp(self):
-        pass
+        ${5:pass}
 
     def tearDown(self):
-        pass
+        ${6:pass}
 
     $0

--- a/python-mode/test_class
+++ b/python-mode/test_class
@@ -4,4 +4,19 @@
 # group : testing
 # --
 class Test${1:toTest}(${2:unittest.TestCase}):
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
     $0


### PR DESCRIPTION
This merge serves to provide a better template for Python unittest classes. A user incrementally chooses whether to modify the setup and teardown methods themselves or leave as 'pass'.

I find in code that even if the testing suite does not utilize setup and teardown methods it is still helpful to leave them there as 'pass' so to tell any reader that this testing suite does not use or require those methods.

It will also perhaps enforce better testing structure down the line for those who might not know about these features of the library.