### PR TITLE
Make c++-mode access specifier snippets indent the first line

### DIFF
--- a/c++-mode/private
+++ b/c++-mode/private
@@ -1,6 +1,7 @@
 # -*- mode: snippet -*-
 # name: private
 # key: pr
+# expand-env: ((yas-also-auto-indent-first-line t))
 # --
 private:
         $0

--- a/c++-mode/protected
+++ b/c++-mode/protected
@@ -1,6 +1,7 @@
 # -*- mode: snippet -*-
 # name: protected
 # key: pt
+# expand-env: ((yas-also-auto-indent-first-line t))
 # --
 protected:
         $0

--- a/c++-mode/public
+++ b/c++-mode/public
@@ -1,6 +1,7 @@
 # -*- mode: snippet -*-
 # name: public
 # key: pb
+# expand-env: ((yas-also-auto-indent-first-line t))
 # --
 public:
         $0


### PR DESCRIPTION
```
The first line of the expansion usually needs to be unindented
relative to the current offset.
* c++-mode/private:
* c++-mode/protected:
* c++-mode/public: Bind yas-also-auto-indent-first-line to t.
```