### PR TITLE
Disable recursive snippets in Clojure namespace snippets

### DIFF
--- a/clojure-mode/import
+++ b/clojure-mode/import
@@ -1,4 +1,5 @@
 # name: import
 # key: import
+# expand-env: ((yas-triggers-in-field nil))
 # --
 (:import ($1))$>

--- a/clojure-mode/require
+++ b/clojure-mode/require
@@ -1,4 +1,5 @@
 # name: require
 # key: require
+# expand-env: ((yas-triggers-in-field nil))
 # --
 (:require [$1 :as $2])$>

--- a/clojure-mode/use
+++ b/clojure-mode/use
@@ -1,4 +1,5 @@
 # name: use
 # key: use
+# expand-env: ((yas-triggers-in-field nil))
 # --
 (:use [$1 :refer [$2]])$>


### PR DESCRIPTION
Previous to this, typing `clojure.test` and then tabbing to go to the next field
would result in an expansion of test.