### PR TITLE
cc-mode: Improve readability of main

### DIFF
--- a/cc-mode/main
+++ b/cc-mode/main
@@ -2,7 +2,7 @@
 # name: main
 # key: main
 # --
-int main(${1:int argc, char *argv[]})
+int main(${1:int argc, char *argv[argc]})
 {
     $0
     return 0;


### PR DESCRIPTION
Each array in argv always contains argc amount of strings. Specify it explicitly
for better readability.