### PR TITLE
Add remote_pry snippets for ruby-mode

### DIFF
--- a/ruby-mode/rpry
+++ b/ruby-mode/rpry
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: binding.pry_remote
+# key: rpry
+# --
+require 'pry-remote'; binding.remote_pry


### PR DESCRIPTION
Hey folks. I'd like to add a new snippet in ruby-mode. 
It's provide remotely debug by pry (using DRb)
I hope it will be usable.
```
require 'pry-remote'; binding.remote_pry
```