### PR TITLE
insert space between "for" keyword and "("

### DIFF
--- a/snippets/js-mode/for
+++ b/snippets/js-mode/for
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
-#name : for
+# name: for
 # --
-for(var ${1:i} = ${2:0}; $1 < ${3:collection}.length; $1++) {
+for (var ${1:i} = ${2:0}; $1 < ${3:collection}.length; $1++) {
   $0
 }

--- a/snippets/js-mode/for
+++ b/snippets/js-mode/for
@@ -1,4 +1,4 @@
-# -*- mode: snippet -*-
+# -*- mode: snippet; require-final-newline: nil -*-
 # name: for
 # --
 for (var ${1:i} = ${2:0}; $1 < ${3:collection}.length; $1++) {


### PR DESCRIPTION
In order to follow main standard JavaScript coding styles, such as:

- [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html)
- [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)
- [JavaScript Standard Style](https://standardjs.com/index.html)
- [Drupal JavaScript coding standards](https://www.drupal.org/docs/develop/standards/javascript/javascript-coding-standards)
- [Crockford's Code Conventions for the JavaScript Programming Language](http://javascript.crockford.com/code.html)