### PR TITLE
use "forEach" instead of "each"

### DIFF
--- a/snippets/js-mode/each
+++ b/snippets/js-mode/each
@@ -1,6 +1,6 @@
-# -*- mode: snippet -*-
-#name : each
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: each
 # --
-${1:collection}.each(function($2) {
+${1:collection}.forEach(function (${2:elem}) {
   $0
 });


### PR DESCRIPTION
"forEach" is standard API, but "each" is non-standard.

See below:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
- https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach