### PR TITLE
Add powershell-mode with basic function snippets

### DIFF
--- a/snippets/powershell-mode/cmdletbinding
+++ b/snippets/powershell-mode/cmdletbinding
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: cmdletbinding
+# key: cmd
+# --
+[cmdletbinding()]
+Param (
+  $0
+)

--- a/snippets/powershell-mode/comment-based-help
+++ b/snippets/powershell-mode/comment-based-help
@@ -1,0 +1,20 @@
+# -*- mode: snippet -*-
+# name: comment-based-help
+# key: cbh
+# --
+<#
+.SYNOPSIS
+${1:Brief description}
+
+.DESCRIPTION
+${2:Longer description}
+
+.PARAMETER Foobar
+${3:Descriptions of parameter Foobar}
+
+.EXAMPLE
+${4:Actual example}
+
+.NOTES
+${5:Additional notes}
+\#>

--- a/snippets/powershell-mode/function
+++ b/snippets/powershell-mode/function
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: function
+# key: fun
+# --
+Function ${1:Verb-Noun} {
+$0
+}

--- a/snippets/powershell-mode/parameter
+++ b/snippets/powershell-mode/parameter
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: parameter
+# key: par
+# --
+[Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)][string]\$${1:Foobar}


### PR DESCRIPTION
Hi Andrea,

I added a couple snippets that make writting PowerShell functions easier.  These are the first snippets I have written and I am not sure if I should be doing things a little different (like the key on comment-based-help being cbh).  If you have any suggestions or quality control issues, please let me know.

I just found out about Yasnippet and it has been great, thank you!

Regards,
Nate