### PR TITLE
Put $0 before comment-end

### DIFF
--- a/snippets/prog-mode/.yas-setup.el
+++ b/snippets/prog-mode/.yas-setup.el
@@ -1,8 +1,5 @@
 (require 'yasnippet)
 
-(defun yas-with-comment (str)
-  (format "%s%s%s" comment-start str comment-end))
-
 ;; whitespace removing functions from Magnar Sveen ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun yas-s-trim-left (s)
   "Remove whitespace at the beginning of S."

--- a/snippets/prog-mode/fixme
+++ b/snippets/prog-mode/fixme
@@ -3,4 +3,4 @@
 # key: fi
 # condition: (not (eq major-mode 'sh-mode))
 # --
-`(yas-with-comment "FIXME: ")`
+`comment-start`FIXME: $0`comment-end

--- a/snippets/prog-mode/todo
+++ b/snippets/prog-mode/todo
@@ -2,4 +2,4 @@
 # name: todo
 # key: t
 # --
-`(yas-with-comment "TODO: ")`
+`comment-start`TODO: $0`comment-end`

--- a/snippets/prog-mode/xxx
+++ b/snippets/prog-mode/xxx
@@ -2,4 +2,4 @@
 # name: xxx
 # key: x
 # --
-`(yas-with-comment "XXX: ")`
+`comment-start`XXX: $0`comment-end`


### PR DESCRIPTION
Fixes joaotavora/yasnippet#854.
```
* snippets/prog-mode/fixme:
* snippets/prog-mode/todo:
* snippets/prog-mode/xxx: Use comment-start and comment-end directly
instead of `yas-with-comment` so that $0 can be inserted before comment-end.
```