### PR TITLE
Update cc-mode/main

### DIFF
--- a/snippets/cc-mode/main
+++ b/snippets/cc-mode/main
@@ -2,7 +2,7 @@
 # name: main
 # key: main
 # --
-int main(${1:int argc, char *argv[argc]})
+int main(${1:int argc, char *argv[]})
 {
     $0
     return 0;


### PR DESCRIPTION
The current cc-mode/main  snippet does not compile out of the box with gcc or g++.
I reverted it to a more standard code which does not use variable length array with its arguments