### PR TITLE
add snippets for 'let' and 'const' statements (ES2015 syntax)

### DIFF
--- a/snippets/js-mode/const
+++ b/snippets/js-mode/const
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: const declaration
+# key: const
+# group: es6
+# --
+const ${1:name} = ${2:initial};

--- a/snippets/js-mode/let
+++ b/snippets/js-mode/let
@@ -1,0 +1,6 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: let declaration
+# key: let
+# group: es6
+# --
+let ${1:name} = ${2:initial};


### PR DESCRIPTION
partial fix for #134 

For details, see below links:

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const