### PR TITLE
Add snippet dir with symbol indirection

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -31,21 +31,21 @@
 
 (require 'yasnippet)
 
-(setq yasnippet-snippets-dir
-      (file-name-directory
-       ;; Copied from ‘f-this-file’ from f.el.
-       (cond
-        (load-in-progress load-file-name)
-        ((and (boundp 'byte-compile-current-file) byte-compile-current-file)
-         byte-compile-current-file)
-        (:else (buffer-file-name)))))
+(defconst yasnippet-snippets-dir
+  (expand-file-name
+   "snippets"
+   (file-name-directory
+    ;; Copied from ‘f-this-file’ from f.el.
+    (cond
+     (load-in-progress load-file-name)
+     ((and (boundp 'byte-compile-current-file) byte-compile-current-file)
+      byte-compile-current-file)
+     (:else (buffer-file-name))))))
 
 ;;;###autoload
 (defun yasnippet-snippets-initialize ()
-  (let ((snip-dir (expand-file-name "snippets" yasnippet-snippets-dir)))
-    (when (boundp 'yas-snippet-dirs)
-      (add-to-list 'yas-snippet-dirs snip-dir t))
-    (yas-load-directory snip-dir)))
+  (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
+  (yas-load-directory yasnippet-snippets-dir))
 
 ;;;###autoload
 (eval-after-load 'yasnippet


### PR DESCRIPTION
Should fix #224, but not really tested properly yet.
```
* yasnippet-snippets.el (yasnippet-snippets-dir): Define with
defconst, set to the "snippets" directory.
(yasnippet-snippets-initialize): Add `yasnippet-snippets-dir' as a
symbol.  Drop the boundp check, as we are already doing (require
'yasnippet).
```