### PR TITLE
Add customization group

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -48,6 +48,16 @@
       (add-to-list 'yas-snippet-dirs snip-dir t))
     (yas-load-directory snip-dir)))
 
+(defgroup yasnippet-snippets nil
+  "Options for yasnippet setups.
+
+This is useful for customizing options declared in
+“.yas-setup.el” files.  For example, you could declare a
+customizable variable used for a snippet expansion.
+
+See Info node `(elisp)Customization Types'."
+  :group 'yasnippet)
+
 ;;;###autoload
 (eval-after-load 'yasnippet
    '(yasnippet-snippets-initialize))

--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -42,6 +42,7 @@
 
 ;;;###autoload
 (defun yasnippet-snippets-initialize ()
+  "Load the `yasnippet-snippets' snippets directory."
   (let ((snip-dir (expand-file-name "snippets" yasnippet-snippets-dir)))
     (when (boundp 'yas-snippet-dirs)
       (add-to-list 'yas-snippet-dirs snip-dir t))


### PR DESCRIPTION
Hi,
I added a customization group that I think will be useful if someone uses the `.yas-setup.el` facilities.  This would allow setting custom snippet preferences (like name of author or the project copyright holders) for snippet expansion.

The group in itself doesn't do anything, but it helps grouping customizable options.