### PR TITLE
Update template

### DIFF
--- a/snippets/emacs-lisp-mode/defvar
+++ b/snippets/emacs-lisp-mode/defvar
@@ -1,4 +1,4 @@
 #name: defvar
 #key: defvar
 # --
-(defvar ${1:symbol}${2: initvalue}${3: "docstring"})
+(defvar ${1:symbol} ${2:initvalue} "${3:docstring}")


### PR DESCRIPTION
Moved spaces that were part of the default values out of them as they are always going to be left in, and moved the quotes outside of the docstring default as they will usually be there.