### PR TITLE
Added Rust snippets "eprint" and "eprintln"

### DIFF
--- a/snippets/rust-mode/eprint
+++ b/snippets/rust-mode/eprint
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: eprint!("{}", value);
+# key: eprint
+# --
+eprint!("${1:{}}", $2);

--- a/snippets/rust-mode/eprintln
+++ b/snippets/rust-mode/eprintln
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: eprintln!("{}", value);
+# key: eprintln
+# --
+eprintln!("${1:{}}", $2);


### PR DESCRIPTION
Hello Andrea,

This PR adds eprint/eprintln Rust snippets which behave like print/println.

* [eprintln](https://doc.rust-lang.org/std/macro.eprintln.html): Macro for printing to the standard error, with a newline.
* [eprint](https://doc.rust-lang.org/std/macro.eprint.html): Macro for printing to the standard error.