### PR TITLE
Remove paren-wrapping snippets from emacs-lisp-mode

### DIFF
--- a/snippets/emacs-lisp-mode/append
+++ b/snippets/emacs-lisp-mode/append
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: append
-#key: append
-# --
-(append $0)

--- a/snippets/emacs-lisp-mode/apply
+++ b/snippets/emacs-lisp-mode/apply
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: apply
-#key: apply
-# --
-(apply $0)

--- a/snippets/emacs-lisp-mode/car
+++ b/snippets/emacs-lisp-mode/car
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: car
-#key: car
-# --
-(car $0)

--- a/snippets/emacs-lisp-mode/cdr
+++ b/snippets/emacs-lisp-mode/cdr
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: cdr
-#key: cdr
-# --
-(cdr $0)

--- a/snippets/emacs-lisp-mode/concat
+++ b/snippets/emacs-lisp-mode/concat
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: concat
-#key: concat
-# --
-(concat $0)

--- a/snippets/emacs-lisp-mode/cons
+++ b/snippets/emacs-lisp-mode/cons
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: cons
-#key: cons
-# --
-(cons $0)

--- a/snippets/emacs-lisp-mode/consp
+++ b/snippets/emacs-lisp-mode/consp
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: consp
-#key: consp
-# --
-(consp $0)

--- a/snippets/emacs-lisp-mode/defsubst
+++ b/snippets/emacs-lisp-mode/defsubst
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: defsubst
-#key: defsubst
-# --
-(defsubst $0)

--- a/snippets/emacs-lisp-mode/dolist
+++ b/snippets/emacs-lisp-mode/dolist
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: dolist
-#key: dolist
-# --
-(dolist $0)

--- a/snippets/emacs-lisp-mode/eq
+++ b/snippets/emacs-lisp-mode/eq
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: eq
-#key: eq
-# --
-(eq $0)

--- a/snippets/emacs-lisp-mode/equal
+++ b/snippets/emacs-lisp-mode/equal
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: equal
-#key: equal
-# --
-(equal $0)

--- a/snippets/emacs-lisp-mode/funcall
+++ b/snippets/emacs-lisp-mode/funcall
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: funcall
-#key: funcall
-# --
-(funcall $0)

--- a/snippets/emacs-lisp-mode/function
+++ b/snippets/emacs-lisp-mode/function
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: function
-#key: function
-# --
-(function $0)

--- a/snippets/emacs-lisp-mode/hash
+++ b/snippets/emacs-lisp-mode/hash
@@ -1,5 +1,0 @@
-# -*- mode: snippet -*-
-# name: hash
-# key: hash
-# --
-(make-hash-table $0)

--- a/snippets/emacs-lisp-mode/if
+++ b/snippets/emacs-lisp-mode/if
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: if
-#key: if
-# --
-(if $0)

--- a/snippets/emacs-lisp-mode/length
+++ b/snippets/emacs-lisp-mode/length
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: length
-#key: length
-# --
-(length $0)

--- a/snippets/emacs-lisp-mode/list
+++ b/snippets/emacs-lisp-mode/list
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: list
-#key: list
-# --
-(list $0)

--- a/snippets/emacs-lisp-mode/mapcar
+++ b/snippets/emacs-lisp-mode/mapcar
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: mapcar
-#key: mapcar
-# --
-(mapcar $0)

--- a/snippets/emacs-lisp-mode/null
+++ b/snippets/emacs-lisp-mode/null
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: null
-#key: null
-# --
-(null $0)

--- a/snippets/emacs-lisp-mode/princ
+++ b/snippets/emacs-lisp-mode/princ
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: princ
-#key: princ
-# --
-(princ $0)

--- a/snippets/emacs-lisp-mode/print
+++ b/snippets/emacs-lisp-mode/print
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: print
-#key: print
-# --
-(print $0)

--- a/snippets/emacs-lisp-mode/progn
+++ b/snippets/emacs-lisp-mode/progn
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: progn
-#key: progn
-# --
-(progn $0)

--- a/snippets/emacs-lisp-mode/push
+++ b/snippets/emacs-lisp-mode/push
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: push
-#key: push
-# --
-(push $0)

--- a/snippets/emacs-lisp-mode/repeat
+++ b/snippets/emacs-lisp-mode/repeat
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: repeat
-#key: repeat
-# --
-(repeat $0)

--- a/snippets/emacs-lisp-mode/require
+++ b/snippets/emacs-lisp-mode/require
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: require
-#key: require
-# --
-(require $0)

--- a/snippets/emacs-lisp-mode/set
+++ b/snippets/emacs-lisp-mode/set
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: set
-#key: set
-# --
-(set $0)

--- a/snippets/emacs-lisp-mode/string
+++ b/snippets/emacs-lisp-mode/string
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: string
-#key: string
-# --
-(string $0)

--- a/snippets/emacs-lisp-mode/stringp
+++ b/snippets/emacs-lisp-mode/stringp
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: stringp
-#key: stringp
-# --
-(stringp $0)

--- a/snippets/emacs-lisp-mode/unless
+++ b/snippets/emacs-lisp-mode/unless
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: unless
-#key: unless
-# --
-(unless $0)

--- a/snippets/emacs-lisp-mode/while
+++ b/snippets/emacs-lisp-mode/while
@@ -1,5 +1,0 @@
-#contributor: Xah Lee (XahLee.org)
-#name: while
-#key: while
-# --
-(while $0)


### PR DESCRIPTION
There are several snippets whose expansion is nothing more than

    (KEY $0)

where KEY is the snippet's #key field.  These snippets do nothing but
save you typing in the parentheses.  Using a package like paredit, or
smartparens would be more suited to this.  There are currently a lot
of snippets in emacs-lisp-mode, which makes browsing through the list
more difficult, so these least useful ones should be removed.