### PR TITLE
Can we use JIT snippet loading?

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -45,7 +45,7 @@
 ;;;###autoload
 (defun yasnippet-snippets-initialize ()
   (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
-  (yas-load-directory yasnippet-snippets-dir))
+  (yas-load-directory yasnippet-snippets-dir t))
 
 ;;;###autoload
 (eval-after-load 'yasnippet


### PR DESCRIPTION
I found that yasnippet now supports JIT snippet loading. Can we make this the default setting when we initialize snippets? From some very basic benchmarking this reduces my load time of yasnippet-snippet autoloads from ~2200 ms to ~400 ms. Further compiling the snippets pushes this down to ~360 ms.