### PR TITLE
Fix indentation python-mode/function_docstring_numpy

### DIFF
--- a/snippets/python-mode/function_docstring_numpy
+++ b/snippets/python-mode/function_docstring_numpy
@@ -5,7 +5,7 @@
 # group: definitions
 # --
 def ${1:name}($2):
-    \"\"\"$3
-    ${2:$(python-args-to-docstring-numpy)}
-    \"\"\"
-    $0
+ \"\"\"$3
+ ${2:$(python-args-to-docstring-numpy)}
+ \"\"\"
+ $0


### PR DESCRIPTION
the indentation was wrong, using only one space instead of 4.