### PR TITLE
rust: add snippets for crate, pub fns, and constructor

### DIFF
--- a/snippets/rust-mode/crate
+++ b/snippets/rust-mode/crate
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: extern crate
+# key: ec
+# --
+extern crate ${0:name};

--- a/snippets/rust-mode/new
+++ b/snippets/rust-mode/new
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: fn main() { ... }
+# key: new
+# --
+pub fn new($1) -> ${2:Name} {
+   $2 { ${3} }
+}

--- a/snippets/rust-mode/pfn
+++ b/snippets/rust-mode/pfn
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: pub fn name() { ... }
+# key: pfn
+# --
+pub fn ${1:name}($2) {
+    $0
+}

--- a/snippets/rust-mode/pfnr
+++ b/snippets/rust-mode/pfnr
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: pub fn name() -> Type { ... }
+# key: pfnr
+# --
+pub fn ${1:name}($2) -> ${3:Type} {
+     $0
+}

--- a/snippets/rust-mode/pfns
+++ b/snippets/rust-mode/pfns
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: pub fn name(&self) -> Type;
+# key: pfns
+# --
+pub fn ${1:name}(${2:&self}) -> ${3:Type};

--- a/snippets/rust-mode/pfnw
+++ b/snippets/rust-mode/pfnw
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: pub fn name<T>(x: T) where T: Clone { ... }
+# key: pfnw
+# --
+pub fn ${1:name}<${2:T}>(${3:x: T}) where ${4:T: Clone} {
+     $0
+}


### PR DESCRIPTION
Some useful snippets for Rust mode that I've found wanting.

- The `extern crate` and the `new` ones are hopefully straightforward. (These are equivalent to the ones I found useful in [Vim Snippets](https://github.com/honza/vim-snippets/blob/master/snippets/rust.snippets).)
- The `pub` variants of all the function snippets is something I've wanted for a long time. Right now I sometimes forget to add `pub` in front and have to go back to the beginning line. Other times, I'll usually add `pub` and then begin the snippet. With the newly added snippets, I hope to provide a canonical way to do them that are analogous to the non-`pub` counterparts.