### PR TITLE
php-mode: fix missing dollar sign in set snippet

### DIFF
--- a/snippets/php-mode/set
+++ b/snippets/php-mode/set
@@ -6,5 +6,5 @@
 # --
 public function set${1:$(capitalize yas-text)}(\$$1)
 {
-    \$this->$1 = $1;
+    \$this->$1 = \$$1;
 }


### PR DESCRIPTION
The dollar sign was missing which caused a badly generated setter
method.

There is still one problem I'd like to fix: capitalize only capitalizes the first letter, but will convert other uppercase characters to lowercase. Any built-in elisp function that will ignore the other upper case characters in a clean way? I only want the first character to be made uppercase.