### PR TITLE
php-mode: fix case in getters and setters

### DIFF
--- a/snippets/php-mode/get
+++ b/snippets/php-mode/get
@@ -4,7 +4,7 @@
 # key: get
 # group: definitions
 # --
-public function get${1:$(capitalize yas-text)}()
+public function get${1:$(upcase-initials yas-text)}()
 {
     return \$this->$1;
 }

--- a/snippets/php-mode/set
+++ b/snippets/php-mode/set
@@ -4,7 +4,7 @@
 # key: set
 # group: definitions
 # --
-public function set${1:$(capitalize yas-text)}(\$$1)
+public function set${1:$(upcase-initials yas-text)}(\$$1)
 {
     \$this->$1 = \$$1;
 }


### PR DESCRIPTION
Fix the case of the getter and setter templates. The previous
method "capitalize" turned upper case characters to lower case
elsewhere in the string.