### PR TITLE
Don't expand Go main package definitions at beginning of buffer

### DIFF
--- a/snippets/go-mode/main
+++ b/snippets/go-mode/main
@@ -1,5 +1,6 @@
 # -*- mode: snippet -*-
 # name: func main()
+# condition: (progn (forward-line 0) (not (and (eq (point-min) (point)) (looking-at-p "package"))))
 # key: main
 # --
 func main() {


### PR DESCRIPTION
Go programs typically start with a main package definition:
```Go
package main // Don't expand

func main() {
}
```