### PR TITLE
Add method snippet to go-mode

### DIFF
--- a/snippets/go-mode/method
+++ b/snippets/go-mode/method
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: method
+# key: mthd
+# contributor: @Kunde21
+# --
+// $2 ${5:...}
+func (${1:recv}) ${2:name}(${3:args}) $4 {
+  $0
+}


### PR DESCRIPTION
Used to add a method to a go struct with documentation comment.