### PR TITLE
Add elisp snippet using uppercase

### DIFF
--- a/snippets/org-mode/elisp
+++ b/snippets/org-mode/elisp
@@ -2,6 +2,6 @@
 # name: elisp
 # key: elisp_
 # --
-#+begin_src emacs-lisp :tangle yes
+#+BEGIN_SRC emacs-lisp :tangle yes
 $0
-#+end_src
+#+END_SRC


### PR DESCRIPTION
By default, `org-mode` inserts blocks in uppercase. I allowed myself to modify the snippet to suit this standard.