### PR TITLE
Remove latex snippet in orgmode.

### DIFF
--- a/snippets/org-mode/latex
+++ b/snippets/org-mode/latex
@@ -1,7 +1,0 @@
-# -*- mode: snippet -*-
-# name: title
-# key: <l
-# --
-#+BEGIN_LATEX
-$0
-#+END_LATEX


### PR DESCRIPTION
The latex snippet "<l" in orgmode is already implemented in orgmode's Easy Templates. Besides, "#+BEGIN_LATEX ... #+END_LATEX" has been replaced with "#+BEGIN_EXPORT latex ... #+END_EXPORT" since orgmode 9.0.