### PR TITLE
c++-mode: fix `tfm` snippet ignored by changing duplicate descriptions

### DIFF
--- a/snippets/c++-mode/ltr
+++ b/snippets/c++-mode/ltr
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-# name: transform
+# name: remove whitespace at beginning
 # key: ltr
 # --
 ${1:container}.erase(0, $1.find_first_not_of(" \t\n\r"));

--- a/snippets/c++-mode/lwr
+++ b/snippets/c++-mode/lwr
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-# name: transform
+# name: string to lower case
 # key: lwr
 # --
 std::transform(std::begin(${1:container}), std::end($1), std::begin($1), [](char c) {


### PR DESCRIPTION
There were multiple snippets going under the name `transform`, and because of that the `tfm` one, which was actually the `transform` function, didn't work. Fix that by changing names in duplicates to what they actually are.