### PR TITLE
[dart-mode] Fix template for async function

### DIFF
--- a/snippets/dart-mode/funca
+++ b/snippets/dart-mode/funca
@@ -2,6 +2,6 @@
 # name: funca
 # key: afun
 # --
-${1:Type} ${2:Name}($3) async {
+Future<${1:Type}> ${2:Name}($3) async {
   $0
 }


### PR DESCRIPTION
Hi, 
This pull request adds only `Future<...>` to template due async function/method has to return `Future` and it's nice to don't write it by hand.