### PR TITLE
Use the same c++ class name placeholder in all c++-mode snippets

### DIFF
--- a/snippets/c++-mode/class
+++ b/snippets/c++-mode/class
@@ -5,7 +5,7 @@
 class ${1:Name}
 {
 public:
-    ${1:$(yas/substr yas-text "[^: ]*")}();
-    ${2:virtual ~${1:$(yas/substr yas-text "[^: ]*")}();}
+    ${1:$(yas-c++-class-name yas-text)}();
+    ${2:virtual ~${1:$(yas-c++-class-name yas-text)}();}
 };
 $0

--- a/snippets/c++-mode/const_[]
+++ b/snippets/c++-mode/const_[]
@@ -2,7 +2,7 @@
 # name: const_[]
 # key: c[
 # --
-const ${1:Type}& operator[](${2:int index}) const
+const ${1:Name}& operator[](${2:int index}) const
 {
         $0
 }

--- a/snippets/c++-mode/constructor
+++ b/snippets/c++-mode/constructor
@@ -2,7 +2,7 @@
 # name: constructor
 # key: ct
 # --
-${1:Class}::$1(${2:args}) ${3: : ${4:init}}
+${1:Name}::$1(${2:args}) ${3: : ${4:init}}
 {
         $0
 }

--- a/snippets/c++-mode/d+=
+++ b/snippets/c++-mode/d+=
@@ -2,4 +2,4 @@
 # name: d+=
 # key: d+=
 # --
-${1:MyClass}& operator+=(${2:const $1 &});
+${1:Name}& operator+=(${2:const $1 &});

--- a/snippets/c++-mode/d_operator
+++ b/snippets/c++-mode/d_operator
@@ -2,4 +2,4 @@
 # name: d_operator<<
 # key: <<
 # --
-friend std::ostream& operator<<(std::ostream&, const ${1:Class}&);
+friend std::ostream& operator<<(std::ostream&, const ${1:Name}&);

--- a/snippets/c++-mode/d_operator[]
+++ b/snippets/c++-mode/d_operator[]
@@ -2,4 +2,4 @@
 # name: d_operator[]
 # key: [
 # --
-${1:Type}& operator[](${2:int index});
+${1:Name}& operator[](${2:int index});

--- a/snippets/c++-mode/d_operator[]_const
+++ b/snippets/c++-mode/d_operator[]_const
@@ -2,4 +2,4 @@
 # name: d_operator[]_const
 # key: c[
 # --
-const ${1:Type}& operator[](${2:int index}) const;
+const ${1:Name}& operator[](${2:int index}) const;

--- a/snippets/c++-mode/d_operator_istream
+++ b/snippets/c++-mode/d_operator_istream
@@ -2,4 +2,4 @@
 # name: d_operator>>
 # key: >>
 # --
-friend std::istream& operator>>(std::istream&, const ${1:Class}&);
+friend std::istream& operator>>(std::istream&, const ${1:Name}&);

--- a/snippets/c++-mode/d_operator_ostream
+++ b/snippets/c++-mode/d_operator_ostream
@@ -2,4 +2,4 @@
 # name: d_operator<<
 # key: <<
 # --
-friend std::ostream& operator<<(std::ostream&, const ${1:Class}&);
+friend std::ostream& operator<<(std::ostream&, const ${1:Name}&);

--- a/snippets/c++-mode/dynamic_casting
+++ b/snippets/c++-mode/dynamic_casting
@@ -2,4 +2,4 @@
 # name: dynamic_casting
 # key: cast
 # --
-check_and_cast<${1:Type} *>(${2:msg});
+check_and_cast<${1:Name} *>(${2:msg});

--- a/snippets/c++-mode/member_function
+++ b/snippets/c++-mode/member_function
@@ -2,7 +2,7 @@
 # name: member_function
 # key: mf
 # --
-${1:type} ${2:Class}::${3:name}(${4:args})${5: const}
+${1:type} ${2:Name}::${3:name}(${4:args})${5: const}
 {
         $0
 }

--- a/snippets/c++-mode/module
+++ b/snippets/c++-mode/module
@@ -2,7 +2,7 @@
 # name: module
 # key: mod
 # --
-class ${1:Class} : public cSimpleModule
+class ${1:Name} : public cSimpleModule
 {
    $0
 }

--- a/snippets/c++-mode/operator!=
+++ b/snippets/c++-mode/operator!=
@@ -3,7 +3,7 @@
 # key: !=
 # group: operator overloading
 # --
-bool ${1:MyClass}::operator!=(const $1 &other) const
+bool ${1:Name}::operator!=(const $1 &other) const
 {
     return !(*this == other);
 }

--- a/snippets/c++-mode/operator+
+++ b/snippets/c++-mode/operator+
@@ -3,7 +3,7 @@
 # key: +
 # group: operator overloading
 # --
-${1:MyClass} $1::operator+(const $1 &other)
+${1:Name} $1::operator+(const $1 &other)
 {
     $1 result = *this;
     result += other;

--- a/snippets/c++-mode/operator+=
+++ b/snippets/c++-mode/operator+=
@@ -3,7 +3,7 @@
 # key: +=
 # group: operator overloading
 # --
-${1:MyClass}& $1::operator+=(${2:const $1 &rhs})
+${1:Name}& $1::operator+=(${2:const $1 &rhs})
 {
   $0
   return *this;

--- a/snippets/c++-mode/operator=
+++ b/snippets/c++-mode/operator=
@@ -4,7 +4,7 @@
 # where this is a reference to myself
 # group: operator overloading
 # --
-${1:MyClass}& $1::operator=(const $1 &rhs)
+${1:Name}& $1::operator=(const $1 &rhs)
 {
     // Check for self-assignment!
     if (this == &rhs)

--- a/snippets/c++-mode/operator==
+++ b/snippets/c++-mode/operator==
@@ -3,7 +3,7 @@
 # key: ==
 # group: operator overloading
 # --
-bool ${1:MyClass}::operator==(const $1 &other) const
+bool ${1:Name}::operator==(const $1 &other) const
 {
      $0
 }

--- a/snippets/c++-mode/operator[]
+++ b/snippets/c++-mode/operator[]
@@ -3,7 +3,7 @@
 # key: []
 # group: operator overloading
 # --
-${1:Type}& operator[](${2:int index})
+${1:Name}& operator[](${2:int index})
 {
         $0
 }

--- a/snippets/c++-mode/operator_istream
+++ b/snippets/c++-mode/operator_istream
@@ -3,7 +3,7 @@
 # key: >>
 # group: operator overloading
 # --
-std::istream& operator>>(std::istream& is, const ${1:Class}& ${2:c})
+std::istream& operator>>(std::istream& is, const ${1:Name}& ${2:c})
 {
          $0
 	 return is;

--- a/snippets/c++-mode/operator_ostream
+++ b/snippets/c++-mode/operator_ostream
@@ -3,7 +3,7 @@
 # key: <<
 # group: operator overloading
 # --
-std::ostream& operator<<(std::ostream& os, const ${1:Class}& ${2:c})
+std::ostream& operator<<(std::ostream& os, const ${1:Name}& ${2:c})
 {
          $0
          return os;


### PR DESCRIPTION
The snippets previously used Class, MyClass, Name and Type. Now it's just Name
in all of them, based on the class11 snippet.

Also replaces `yas/substr` calls in c++-mode/class with `yas-c++-class-name`.