### PR TITLE
Add scala-mode snippet to define functions along with their docstring

### DIFF
--- a/snippets/scala-mode/docfun
+++ b/snippets/scala-mode/docfun
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# name: docstring function
+# contributor: Andrea Giugliano
+# inspired by a snippet by Tibor Simko et al.
+# --
+/**
+ * $1
+ * ${3:$
+    (let* ((indent
+            (concat "\n * "))
+           (args
+            (mapconcat
+             '(lambda (x)
+                (if (not (string= (nth 0 x) ""))
+                    ;; in Scala I get a separator : for the type
+                    (let ((par-type (mapcar 'string-trim (split-string (nth 0 x) ":")))) (concat "@param " (first par-type) indent "@tparam " (second par-type) indent))
+                    ))
+             (mapcar
+              '(lambda (x)
+                 (mapcar
+                  '(lambda (x)
+                     (replace-regexp-in-string "[[:blank:]]*$" ""
+                      (replace-regexp-in-string "^[[:blank:]]*" "" x)))
+                  x))
+              (mapcar '(lambda (x) (split-string x "="))
+                      (split-string yas-text ",")))
+             indent)))
+      (if (string= args "")
+          (concat indent "@return: " indent "@rtype: " indent (make-string 3 34))
+        (mapconcat
+         'identity
+         (list "" args )
+         indent)))
+    }
+ * @return ${4:$(yas-text)}
+ *
+ **/
+def ${2:name}($3): $4 = $0


### PR DESCRIPTION
Hi there,

Thanks for this repository! I have been using your snippets a lot: I am very grateful.

Recently I needed a snippet to add documentation to functions during my Scala work.

After seeing a Python snippet [0], I adapted its code to work for Scala.
How can I improve it to make it available to others through your repository?

Thanks,

Andrea

[0] http://blog.yitang.uk/2015/09/24/how-to-create-a-screencast-gif-in-emacs/