### PR TITLE
Snippets for dataclasses and enumerations

### DIFF
--- a/snippets/python-mode/dataclass
+++ b/snippets/python-mode/dataclass
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: dataclass
+# key: dc
+# group: object oriented
+# --
+@dataclass
+class ${1:class}:
+    $0

--- a/snippets/python-mode/enum
+++ b/snippets/python-mode/enum
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: enum
+# key: en
+# group: object oriented
+# --
+class ${1:class}(Enum):
+    $0


### PR DESCRIPTION
Added snippets for `Enum` that has been introduced in Python 3.4 and `dataclasses` introduced in Python 3.7