### PR TITLE
Fix incorrect language classification on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Stop HTML documents from skewing the repository's language stats
+*.html linguist-generated=true


### PR DESCRIPTION
[`851d287`](https://github.com/AndreaCrotti/yasnippet-snippets/commit/851d287fc7b75eeef1e4036f309e6ad55ae5b0b8) brought in a huge wad of generated HTML, which has changed the repository's language classification on GitHub:

![figure-1](https://user-images.githubusercontent.com/2346707/54476146-db462600-484d-11e9-90b6-aa83bc6ab3f8.png)

This PR addresses that by adding an [override](https://github.com/github/linguist#overrides) to mark the HTML file as generated and stop it from skewing the project's language stats.