### PR TITLE
Elixir: make hcall, hcast, and hinfo snippets more general

### DIFF
--- a/snippets/elixir-mode/hcall
+++ b/snippets/elixir-mode/hcall
@@ -2,7 +2,6 @@
 # name: hcall
 # key: hcall
 # --
-def handle_call($1, _from, state) do
-  reply = $0
-  {:reply, reply, state}
+def handle_call($1, _from, ${2:state}) do
+  $0
 end

--- a/snippets/elixir-mode/hcast
+++ b/snippets/elixir-mode/hcast
@@ -2,7 +2,6 @@
 # name: hcast
 # key: hcast
 # --
-def handle_cast($1, state) do
+def handle_cast($1, ${2:state}) do
   $0
-  {:noreply, state}
 end

--- a/snippets/elixir-mode/hinfo
+++ b/snippets/elixir-mode/hinfo
@@ -2,7 +2,6 @@
 # name: hinfo
 # key: hinfo
 # --
-def handle_info($1, state) do
+def handle_info($1, ${2:state}) do
   $0
-  {:noreply, state}
 end


### PR DESCRIPTION
Hi, 
The current version of handle_call and handle_cast is too specific. Most of the time, I have to change variable name (state) and delete code.