### PR TITLE
Perl #!/usr/bin/perl, use strict, use warnings.

### DIFF
--- a/snippets/org-mode/author
+++ b/snippets/org-mode/author
@@ -2,4 +2,4 @@
 # name: author
 # key: <au
 # --
-#+AUTHOR: $0
+#+author: $0

--- a/snippets/org-mode/center
+++ b/snippets/org-mode/center
@@ -2,6 +2,6 @@
 # name: center
 # key: <c
 # --
-#+BEGIN_CENTER
+#+begin_center
 $0
-#+END_CENTER
+#+end_center

--- a/snippets/org-mode/date
+++ b/snippets/org-mode/date
@@ -2,4 +2,4 @@
 # name: date
 # key: <da
 # --
-#+DATE: ${1:Year}:${2:month}:${3:day}
+#+date: ${1:year}:${2:month}:${3:day}

--- a/snippets/org-mode/description
+++ b/snippets/org-mode/description
@@ -2,4 +2,4 @@
 # name: description
 # key: desc
 # --
-#+DESCRIPTION: $0
+#+description: $0

--- a/snippets/org-mode/dot
+++ b/snippets/org-mode/dot
@@ -2,7 +2,7 @@
 # name: dot
 # key: dot_
 # --
-#+begin_src dot :file ${1:file} :cmdline -T${2:pdf} :exports none :results silent
+#+begin_src dot :file ${1:file} :cmdline -t${2:pdf} :exports none :results silent
 $0
 #+end_src
 [[file:${3:path}]]

--- a/snippets/org-mode/elisp
+++ b/snippets/org-mode/elisp
@@ -2,6 +2,6 @@
 # name: elisp
 # key: elisp_
 # --
-#+BEGIN_SRC emacs-lisp :tangle yes
+#+begin_src emacs-lisp :tangle yes
 $0
-#+END_SRC
+#+end_src

--- a/snippets/org-mode/emacs-lisp
+++ b/snippets/org-mode/emacs-lisp
@@ -2,6 +2,6 @@
 # name: emacs-lisp
 # key: emacs-lisp_
 # --
-#+BEGIN_SRC emacs-lisp :tangle yes
+#+begin_src emacs-lisp :tangle yes
 $0
-#+END_SRC
+#+end_src

--- a/snippets/org-mode/email
+++ b/snippets/org-mode/email
@@ -2,4 +2,4 @@
 # name: email
 # key: <em
 # --
-#+EMAIL: $0
+#+email: $0

--- a/snippets/org-mode/exampleblock
+++ b/snippets/org-mode/exampleblock
@@ -2,6 +2,6 @@
 # name: example
 # key: <e
 # --
-#+BEGIN_EXAMPLE
+#+begin_example
 $0
-#+END_EXAMPLE
+#+end_example

--- a/snippets/org-mode/export
+++ b/snippets/org-mode/export
@@ -2,6 +2,6 @@
 # name: export
 # key: <ex
 # --
-#+BEGIN_EXPORT ${1:type}
+#+begin_export ${1:type}
 $0
-#+END_EXPORT
+#+end_export

--- a/snippets/org-mode/figure
+++ b/snippets/org-mode/figure
@@ -2,6 +2,6 @@
 # name: figure
 # key: fig_
 # --
-#+CAPTION: ${1:caption}
-#+ATTR_LaTeX: ${2:scale=0.75}
-#+LABEL: fig:${3:label}$0
+#+caption: ${1:caption}
+#+attr_latex: ${2:scale=0.75}
+#+label: fig:${3:label}$0

--- a/snippets/org-mode/html
+++ b/snippets/org-mode/html
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-# name: HTML
-# key: <HT
+# name: html
+# key: <ht
 # --
-#+HTML:$1
+#+html:$1

--- a/snippets/org-mode/include
+++ b/snippets/org-mode/include
@@ -2,4 +2,4 @@
 # name: include
 # key: <i
 # --
-#+INCLUDE: $0
+#+include: $0

--- a/snippets/org-mode/ipython
+++ b/snippets/org-mode/ipython
@@ -2,6 +2,6 @@
 # name: ipython
 # key: ipy_
 # --
-#+BEGIN_SRC ipython :session ${1:session01} :file ${2:$$(concat (make-temp-name "./ipython-") ".png")} :exports ${3:both}
+#+begin_src ipython :session ${1:session01} :file ${2:$$(concat (make-temp-name "./ipython-") ".png")} :exports ${3:both}
 $0
-#+END_SRC
+#+end_src

--- a/snippets/org-mode/keywords
+++ b/snippets/org-mode/keywords
@@ -2,4 +2,4 @@
 # name: keywords
 # key: <ke
 # --
-#+KEYWORDS: $0
+#+keywords: $0

--- a/snippets/org-mode/language
+++ b/snippets/org-mode/language
@@ -2,4 +2,4 @@
 # name: language
 # key: <lan
 # --
-#+LANGUAGE: ${1:en}
+#+language: ${1:en}

--- a/snippets/org-mode/link
+++ b/snippets/org-mode/link
@@ -2,4 +2,4 @@
 # name: link
 # key: <li
 # --
-[[${1:external_link}][${2:Description}]
+[[${1:external_link}][${2:description}]

--- a/snippets/org-mode/options
+++ b/snippets/org-mode/options
@@ -2,4 +2,4 @@
 # name: options
 # key: <op
 # --
-#+OPTIONS: H:${1:1} num:${2:t||nil} toc:${3:t||nil}$0
+#+options: h:${1:1} num:${2:t||nil} toc:${3:t||nil}$0

--- a/snippets/org-mode/python
+++ b/snippets/org-mode/python
@@ -2,6 +2,6 @@
 # name: python
 # key: py_
 # --
-#+BEGIN_SRC python
+#+begin_src python
 $0
-#+END_SRC
+#+end_src

--- a/snippets/org-mode/quote
+++ b/snippets/org-mode/quote
@@ -2,6 +2,6 @@
 # name: quote
 # key: <q
 # --
-#+BEGIN_QUOTE
+#+begin_quote
 $0
-#+END_QUOTE
+#+end_quote

--- a/snippets/org-mode/rv_background
+++ b/snippets/org-mode/rv_background
@@ -3,6 +3,6 @@
 # key: <rsb
 # --
 
-:PROPERTIES:
+:properties:
 :reveal_background: ${1: #123456}
-:END:
+:end:

--- a/snippets/org-mode/rv_image_background
+++ b/snippets/org-mode/rv_image_background
@@ -3,7 +3,7 @@
 # key: <rib
 # --
 
-    :PROPERTIES:
+    :properties:
     :reveal_background: ${1: path of the image}
     :reveal_background_trans: ${2: default||cube||page||concave||zoom||linear||fade||none||slide}
-    :END:
+    :end:

--- a/snippets/org-mode/setup
+++ b/snippets/org-mode/setup
@@ -2,4 +2,4 @@
 # name: setup
 # key: set
 # --
-#+SETUPFILE: $0
+#+setupfile: $0

--- a/snippets/org-mode/style
+++ b/snippets/org-mode/style
@@ -2,4 +2,4 @@
 # name: style
 # key: <st
 # --
-#+STYLE: <link rel="stylesheet" type="text/css" href="$1" />
+#+style: <link rel="stylesheet" type="text/css" href="$1" />

--- a/snippets/org-mode/table
+++ b/snippets/org-mode/table
@@ -2,6 +2,6 @@
 # name: table
 # key: <ta
 # --
-#+CAPTION: ${1: caption of the table}
+#+caption: ${1: caption of the table}
 |${2:column 1} | ${3: column 2} |
 |--------------+----------------|

--- a/snippets/org-mode/title
+++ b/snippets/org-mode/title
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-# name: Title
+# name: title
 # key: <ti
 # --
-#+TITLE: $0
+#+title: $0

--- a/snippets/org-mode/uml
+++ b/snippets/org-mode/uml
@@ -1,8 +1,8 @@
 # -*- mode: snippet -*-
 # name: uml
 # key: uml
-# contributor : Robert O'Connor
+# contributor : robert o'connor
 # --
-#+BEGIN_UML
+#+begin_uml
 $1
-#+END_UML
+#+end_uml

--- a/snippets/org-mode/verse
+++ b/snippets/org-mode/verse
@@ -2,6 +2,6 @@
 # name: verse
 # key: <v
 # --
-#+BEGIN_VERSE
+#+begin_verse
 $0
-#+END_VERSE
+#+end_verse

--- a/snippets/org-mode/video
+++ b/snippets/org-mode/video
@@ -2,5 +2,5 @@
 # name: video
 # key: <vi
 # --
-##videos must be used with an image..so when image is clicked video starts
+
 [[${1:link of the video}][file:${2:link of the image}]

--- a/snippets/perl-mode/use
+++ b/snippets/perl-mode/use
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: use
+# key: use_
+# contributor: Spenser Truex
+# --
+#!/usr/bin/perl
+use warnings;
+use strict;
+$0


### PR DESCRIPTION
This heading is standard in perl code, I actually have it auto-insert (using the `autoinsert` for Emacs) whenever I open a `.pl` file. A lot of perl programs have no file ending, since they are meant as executables, so I'd like to have it in my yasnippets.