### PR TITLE
Adds several flutter snippets for dart-mode

### DIFF
--- a/snippets/dart-mode/didchangedependencies
+++ b/snippets/dart-mode/didchangedependencies
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: didChangeDependencies
+# key: dcd
+# group: flutter
+# --
+@override
+void didChangeDependencies() {
+  super.didChangeDependencies();
+  $0
+}

--- a/snippets/dart-mode/dispose
+++ b/snippets/dart-mode/dispose
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: dispose
+# key: is
+# group: flutter
+# --
+@override
+void dispose() {
+  super.dispose();
+  $0
+}

--- a/snippets/dart-mode/initstate
+++ b/snippets/dart-mode/initstate
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: initState
+# key: is
+# group: flutter
+# --
+@override
+void initState() {
+  super.initState();
+  $0
+}

--- a/snippets/dart-mode/statefulwidget
+++ b/snippets/dart-mode/statefulwidget
@@ -1,0 +1,16 @@
+# -*- mode: snippet -*-
+# name: StatefulWidget
+# key: sfw
+# group: flutter
+# --
+class ${1:Name} extends StatefulWidget {
+  @override
+  $1State createState() => $1State();
+}
+
+class $1State extends State<$1> {
+  @override
+  Widget build(BuildContext context) {
+    return Container($0);
+  }
+}

--- a/snippets/dart-mode/statelesswidget
+++ b/snippets/dart-mode/statelesswidget
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: StatelessWidget
+# key: slw
+# group: flutter
+# --
+class ${1:Name} extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container($0);
+  }
+}


### PR DESCRIPTION
Some initial progress on adding snippets for flutter. For example, the following sample from https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html would be easier to input.

``` dart
class YellowBird extends StatefulWidget {
  const YellowBird({ Key key }) : super(key: key);

  @override
  _YellowBirdState createState() => _YellowBirdState();
}

class _YellowBirdState extends State<YellowBird> {
  @override
  Widget build(BuildContext context) {
    return Container(color: const Color(0xFFFFE306));
  }
}
```