### PR TITLE
Add perl use snippet.

### DIFF
--- a/snippets/perl-mode/use
+++ b/snippets/perl-mode/use
@@ -1,0 +1,9 @@
+# -*- mode: snippet -*-
+# name: use
+# key: use_
+# contributor: Spenser Truex
+# --
+#!/usr/bin/perl
+use warnings;
+use strict;
+$0


### PR DESCRIPTION
This heading is standard in perl code, I actually have it auto-insert (using the autoinsert for Emacs) whenever I open a .pl file. A lot of perl programs have no file ending, since they are meant as executables, so I'd like to have it in my yasnippets.