### PR TITLE
Org not underline

### DIFF
--- a/snippets/org-mode/link
+++ b/snippets/org-mode/link
@@ -2,4 +2,4 @@
 # name: link
 # key: <li
 # --
-[[${1:external_link}][${2:description}]
+[[${1:link}][${2:description}]


### PR DESCRIPTION
![org-subscript](https://user-images.githubusercontent.com/13551856/64081981-feaa4380-ccbc-11e9-86d4-f9de785e9ac2.png)

This kind of underlining now gets turned into a subscript in org, so I removed it (since the raw code in the old one is `external_link`.
