### PR TITLE
Source block without any language pre-defined (like the elisp snippet)

### DIFF
--- a/snippets/org-mode/src
+++ b/snippets/org-mode/src
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: src
+# key: src_
+# --
+#+begin_src $0
+#+end_src


### PR DESCRIPTION
I have deleted the ` emacs-lisp :tangle yes` portion of the `elisp` snippet enough times to make we want to have this pull request. It adds a new `src` snippet.

Would it be better to also remove the `elisp` snippet, since it is a bit arbitrarily specific? Org mode can support any language you want in the src blocks, so I think this is a good thing. 