### PR TITLE
Renamed "switch" (which is not in lisp) to "cond" which is.

### DIFF
--- a/snippets/lisp-mode/cond
+++ b/snippets/lisp-mode/cond
@@ -1,9 +1,9 @@
 # -*- mode: snippet -*-
-# name: switch
-# key: switch
+# name: cond
+# key: cond
 # --
 
 (cond (${1:case1} (${2:do-this}))
-      (${3:case2} (${4:do-this}))     
+      (${3:case2} (${4:do-this}))
       (t ${5:default}))
 $0


### PR DESCRIPTION
Not sure why this was named `switch`, it is a `cond`. `cond` is not close to switch in ALGOL derivates at all.