### PR TITLE
Py docstring type annotation

### DIFF
--- a/snippets/python-mode/.yas-setup.el
+++ b/snippets/python-mode/.yas-setup.el
@@ -2,9 +2,12 @@
 (defvar yas-text)
 
 (defun python-split-args (arg-string)
-  "Split a python argument string into ((name, default)..) tuples"
+  "Split a python argument string ARG-STRING into ((name, default)..) tuples."
   (mapcar (lambda (x)
-             (split-string x "[[:blank:]]*=[[:blank:]]*" t))
+            (list (and (string-match "[[:word:]]+" x)
+                       (match-string 0 x))
+                  (and (string-match "=[[:blank:]]*\\(.*\\)" x)
+                       (match-string 1 x))))
           (split-string arg-string "[[:blank:]]*,[[:blank:]]*" t)))
 
 (defun python-args-to-docstring ()

--- a/snippets/python-mode/.yas-setup.el
+++ b/snippets/python-mode/.yas-setup.el
@@ -8,7 +8,9 @@
                        (match-string 0 x))
                   (and (string-match "=[[:blank:]]*\\(.*\\)" x)
                        (match-string 1 x))))
-          (split-string arg-string "[[:blank:]]*,[[:blank:]]*" t)))
+          (split-string
+           (replace-regexp-in-string "\n" " " arg-string)
+           "[[:blank:]]*,[[:blank:]]*" t)))
 
 (defun python-args-to-docstring ()
   "return docstring format for the python arguments in yas-text"


### PR DESCRIPTION
A few tweaks to the Python snippet fn for handling of args to generating docstrings, e.g. the `function_docstring` (key `fd`) snippet.

Before this it was upset by newlines in arg lists, e.g.
``` python
def foo(
        arg1,
        arg2,
):
```

And in addition, it didn't know what to do with type annotations, e.g:
``` python
def foo(
        arg1: int,
        arg2: str = 'default string',
):
```

It now excludes the type annotation from the docstring.

(I could see an argument for removing the default handling - my personal preference is to avoid duplicating the information - I'd be happy to modify the PR to do that, but who knows which users use and like this.)