### PR TITLE
Change variable order in Python try snippets

### DIFF
--- a/snippets/python-mode/try
+++ b/snippets/python-mode/try
@@ -3,6 +3,6 @@
 # key: try
 # --
 try:
-    $1
-except ${2:Exception}:
     $0
+except ${1:Exception}:
+    $2

--- a/snippets/python-mode/tryelse
+++ b/snippets/python-mode/tryelse
@@ -3,8 +3,8 @@
 # key: try
 # --
 try:
-    $1
-except $2:
-    $3
-else:
     $0
+except $1:
+    $2
+else:
+    $3


### PR DESCRIPTION
By changing the code inside the try block to $0 it is possible to wrap the action region with a
try/except block when yas-wrap-around-region is set to t.