### PR TITLE
Don't add anonymous functions to hooks, use named functions instead

### DIFF
--- a/snippets/bibtex-mode/.yas-setup.el
+++ b/snippets/bibtex-mode/.yas-setup.el
@@ -1,4 +1,3 @@
 (require 'yasnippet)
 
-(add-hook 'bibtex-mode-hook
-          '(lambda () (set (make-local-variable 'yas-indent-line) nil)))
+(add-hook 'bibtex-mode-hook #'yasnippet-snippets--no-indent)

--- a/snippets/python-mode/.yas-setup.el
+++ b/snippets/python-mode/.yas-setup.el
@@ -35,5 +35,4 @@
                  "\n"))))
 
 
-(add-hook 'python-mode-hook
-          '(lambda () (set (make-local-variable 'yas-indent-line) 'fixed)))
+(add-hook 'python-mode-hook #'yasnippet-snippets--fixed-indent)

--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -58,6 +58,14 @@ customizable variable used for a snippet expansion.
 See Info node `(elisp)Customization Types'."
   :group 'yasnippet)
 
+(defun yasnippet-snippets--fixed-indent ()
+  "Set `yas-indent-line' to `fixed'."
+  (set (make-local-variable 'yas-indent-line) 'fixed))
+
+(defun yasnippet-snippets--no-indent ()
+  "Set `yas-indent-line' to nil."
+  (set (make-local-variable 'yas-indent-line) nil))
+
 ;;;###autoload
 (eval-after-load 'yasnippet
    '(yasnippet-snippets-initialize))


### PR DESCRIPTION
This makes the functions transparent (clear where they came from) and
accessible (compilable, removable, reusable, redefinable).