### PR TITLE
Add snippets for Dockerfile, Fish shell, JavaScript, Perl, and Org

### DIFF
--- a/snippets/dockerfile-mode/alpine-dockerize
+++ b/snippets/dockerfile-mode/alpine-dockerize
@@ -1,0 +1,12 @@
+# -*- mode: snippet -*-
+# name: dockerize for Alpine Images
+# key: alpine-dockerize
+# expand-env: ((yas-indent-line 'fixed) (yas-wrap-around-region nil))
+# --
+ENV DOCKERIZE_VERSION ${1:v0.6.1}
+
+RUN apk update && \
+  apk --no-cache add openssl && \
+  wget https://github.com/jwilder/dockerize/releases/download/\${DOCKERIZE_VERSION}/dockerize-alpine-linux-amd64-\${DOCKERIZE_VERSION}.tar.gz && \
+  tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-\${DOCKERIZE_VERSION}.tar.gz && \
+  rm dockerize-alpine-linux-amd64-\${DOCKERIZE_VERSION}.tar.gz

--- a/snippets/fish-mode/bang
+++ b/snippets/fish-mode/bang
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: bang
+# key: !
+# --
+#!/usr/bin/env fish
+$0

--- a/snippets/fish-mode/block
+++ b/snippets/fish-mode/block
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: begin ... end
+# key: block
+# --
+begin
+    $0
+end

--- a/snippets/fish-mode/bp
+++ b/snippets/fish-mode/bp
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: breakpoint
+# key: bp
+# --
+breakpoint
+$0

--- a/snippets/fish-mode/for
+++ b/snippets/fish-mode/for
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: for loop
+# key: for
+# --
+for ${1:var} in ${2:stuff}
+    $0
+end

--- a/snippets/fish-mode/function
+++ b/snippets/fish-mode/function
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: function
+# key: function
+# --
+function ${1:name}
+    $0
+end

--- a/snippets/fish-mode/if
+++ b/snippets/fish-mode/if
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: if ... end
+# key: if
+# --
+if ${1:[ -f file ]}
+    ${2:do}
+end
+$0

--- a/snippets/fish-mode/ife
+++ b/snippets/fish-mode/ife
@@ -1,0 +1,10 @@
+# -*- mode: snippet -*-
+# name: if ... ... else ... end
+# key: ife
+# --
+if ${1:cond}
+    ${2:stuff}
+else
+    ${3:other}
+end
+$0

--- a/snippets/fish-mode/sw
+++ b/snippets/fish-mode/sw
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: switch
+# key: sw
+# --
+switch ${1:condition}
+    case ${2:*}
+         ${0}
+end

--- a/snippets/fish-mode/while
+++ b/snippets/fish-mode/while
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: while loop
+# key: while
+# --
+while ${1:cond}
+    $0
+end

--- a/snippets/js-mode/flow
+++ b/snippets/js-mode/flow
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: /* @flow */
+# key: flow
+# --
+/* @flow */

--- a/snippets/org-mode/src
+++ b/snippets/org-mode/src
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: src
+# key: <src
+# --
+#+BEGIN_SRC $1
+  $0
+#+END_SRC

--- a/snippets/perl-mode/bang
+++ b/snippets/perl-mode/bang
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: bang
+# key: !
+# --
+#!/usr/bin/env perl
+$0

--- a/snippets/perl-mode/enc
+++ b/snippets/perl-mode/enc
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: encoding
+# key: enc
+# --
+binmode STDOUT, ':encoding(UTF-8)';
+binmode STDERR, ':encoding(UTF-8)';
+$0

--- a/snippets/perl-mode/strict
+++ b/snippets/perl-mode/strict
@@ -1,9 +1,8 @@
 # -*- mode: snippet -*-
-# name: use
-# key: use_
+# name: strict
+# key: strict
 # contributor: Spenser Truex
 # --
-#!/usr/bin/perl
 use warnings;
 use strict;
 $0


### PR DESCRIPTION
## Dockerfile

- `alpine-dockerize`

## Fish shell

- `bang`
- `block`
- `bp`
- `for`
- `function`
- `if`
- `ife`
- `sw`
- `while`

## JavaScript

- `flow`

## Perl

- `bang`
- `enc`
- Remove the shebang from `use` and rename it `strict`

## Org

- `src`