### PR TITLE
fix initializer

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -45,7 +45,7 @@
 ;;;###autoload
 (defun yasnippet-snippets-initialize ()
   "Load the `yasnippet-snippets' snippets directory."
-  (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
+  (add-to-list 'yas-snippet-dirs yasnippet-snippets-dir t)
   (yas-load-directory yasnippet-snippets-dir t))
 
 (defgroup yasnippet-snippets nil


### PR DESCRIPTION
Currently, the symbol yasnippet-snippets-dir ends up being added to the
yas-snippet-dirs list instead of the value of yasnippet-snippets-dir.