### PR TITLE
Revert "fix initializer", adding the symbol is correct

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -45,7 +45,10 @@
 ;;;###autoload
 (defun yasnippet-snippets-initialize ()
   "Load the `yasnippet-snippets' snippets directory."
-  (add-to-list 'yas-snippet-dirs yasnippet-snippets-dir t)
+  ;; NOTE: we add the symbol `yasnippet-snippets-dir' rather than its
+  ;; value, so that yasnippet will automatically find the directory
+  ;; after this package is updated (i.e., moves directory).
+  (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
   (yas-load-directory yasnippet-snippets-dir t))
 
 (defgroup yasnippet-snippets nil


### PR DESCRIPTION
Actually, the change from #358 was a mistake.