### PR TITLE
org-mode/src: Suppress indentation

### DIFF
--- a/snippets/org-mode/src
+++ b/snippets/org-mode/src
@@ -1,6 +1,7 @@
 # -*- mode: snippet -*-
 # name: src
 # key: <src
+# expand-env: ((org-src-tab-acts-natively nil))
 # --
 #+BEGIN_SRC $1
   $0


### PR DESCRIPTION
Before this change, trying to use the `org-mode/src` snippet with `org-src-tab-acts-natively` set to `t` would insert the snippet, print an error message in the echo area: "No such language mode: nil-mode", and leave point at the beginning of the first line of the snippet.

After this change, the snippet is expanded with no error message and with point in the correct position.

This change fixes https://github.com/joaotavora/yasnippet/issues/863.

* `snippets/org-mode/src`: Set `org-src-tab-acts-natively` to `nil` to prevent Org-Mode from trying to indent the block with nil major mode.