### PR TITLE
Add built_value for dart

### DIFF
--- a/snippets/dart-mode/builtvalue
+++ b/snippets/dart-mode/builtvalue
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: built_value
+# key: blt
+# group: dart
+# --
+abstract class ${1:Name} implements Built<$1, $1Builder> {
+  factory $1([void Function($1Builder) updates]) = _$$1;
+  $1._();
+
+  $0
+}

--- a/snippets/dart-mode/dispose
+++ b/snippets/dart-mode/dispose
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: dispose
-# key: is
+# key: dis
 # group: flutter
 # --
 @override


### PR DESCRIPTION
From https://github.com/google/built_value.dart#generating-boilerplate-for-value-types

abstract class $CLASS_NAME$ implements Built<$CLASS_NAME$, $CLASS_NAME$Builder> {
  $CLASS_NAME$._();
  factory $CLASS_NAME$([void Function($CLASS_NAME$Builder) updates]) = _$$$CLASS_NAME$;
}