### PR TITLE
Add more bibtex snippets

### DIFF
--- a/snippets/bibtex-mode/bookinbook
+++ b/snippets/bibtex-mode/bookinbook
@@ -1,0 +1,22 @@
+# -*- mode: snippet -*-
+# name: bookinbook
+# key: bookinbook
+# author: Spenser Truex
+# --
+@bookinbook{ ${title},
+author    = {${author}},
+title     = {${title}},
+chapter   = {${chapter}}${,
+pages     = {${pages}}},
+publisher = {${publisher}},
+year      = {${year}},
+volume    = {${volume}}${,
+series    = {${series}}}${,
+type      = {${type}}}${,
+address   = {${address}}}${,
+edition   = {${edition}}}${,
+month     = {${month}}}${,
+note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/collection
+++ b/snippets/bibtex-mode/collection
@@ -1,0 +1,22 @@
+# -*- mode: snippet -*-
+# name: collection
+# key: collection
+# author: Spenser Truex
+# --
+@collection{ ${title},
+  editor    = {${editor}},
+  title     = {${title}},
+  year      = {${year}}${,
+  publisher = {${publisher}}}${,
+  volume    = {${volume}}}${,
+  series    = {${series}}}${,
+  type      = {${type}}}${,
+  chapter   = {${chapter}}}${,
+  pages     = {${pages}}}${,
+  address   = {${address}}}${,
+  edition   = {${edition}}}${,
+  month     = {${month}}}${,
+  note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/dataset
+++ b/snippets/bibtex-mode/dataset
@@ -1,0 +1,17 @@
+# -*- mode: snippet -*-
+# name: dataset
+# key: dataset
+# author: Spenser Truex
+# --
+@dataset{ ${title}
+  title        = {${title}},
+  editor       = {${editor}},
+  year         = {${year}}${,
+  author       = {${author}}}${,
+  volume       = {${volume}}}${,
+  version      = {${version}}}${,
+  publisher    = {${publisher}}}${,
+  organization = {${organization}}}${,
+  note         = {${note}}}
+
+}

--- a/snippets/bibtex-mode/electronic
+++ b/snippets/bibtex-mode/electronic
@@ -1,0 +1,14 @@
+# -*- mode: snippet -*-
+# name: electronic
+# key: electronic
+# author: Spenser Truex
+# --
+@electronic{ ${title},
+author  = {${author}},
+title   = {${title}},
+year    = {${year}},
+url     = {${url}}${,
+editor  = {${editor}}}${,
+urldate = {${urldate}}}${,
+note    = {${note}}}
+}

--- a/snippets/bibtex-mode/inreference
+++ b/snippets/bibtex-mode/inreference
@@ -1,0 +1,24 @@
+# -*- mode: snippet -*-
+# name: inreference
+# key: inreference
+# author: Spenser Truex
+# --
+@inreference{ ${title},
+author    = {${author}},
+title     = {${title}},
+booktitle = {${booktitle}},
+publisher = {${publisher}},
+year      = {${year}}${,
+editor    = {${editor}}}${,
+volume    = {${volume}}}${,
+series    = {${series}}}${,
+type      = {${type}}}${,
+chapter   = {${chapter}}}${,
+pages     = {${pages}}}${,
+address   = {${address}}}${,
+edition   = {${edition}}}${,
+month     = {${month}}}${,
+note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/mvbook
+++ b/snippets/bibtex-mode/mvbook
@@ -1,20 +1,22 @@
 # -*- mode: snippet -*-
-# name: inbook
-# key: inbook
+# name: mvbook
+# key: mvbook
+# author: Spenser Truex
 # --
-@inbook{ ${title},
+@mvbook{ ${title},
   author    = {${author}},
   title     = {${title}},
-  chapter   = {${chapter}}${,
-  pages     = {${pages}}},
-  publisher = {${publisher}},
-  year      = {${year}},
-  volume    = {${volume}}${,
+  year      = {${year}}${,
+  volume    = {${volume}}}${,
+  editor    = {${editor}}}${,
+  publisher = {${publisher}}}${,
+  number    = {${number}}}${,
   series    = {${series}}}${,
   type      = {${type}}}${,
   address   = {${address}}}${,
   edition   = {${edition}}}${,
   month     = {${month}}}${,
+  isbn      = {${isbn}}}${,
   note      = {${note}}}
 }
 

--- a/snippets/bibtex-mode/mvcollection
+++ b/snippets/bibtex-mode/mvcollection
@@ -1,0 +1,22 @@
+# -*- mode: snippet -*-
+# name: mvcollection
+# key: mvcollection
+# author: Spenser Truex
+# --
+@mvcollection{ ${title},
+  editor    = {${editor}},
+  title     = {${title}},
+  year      = {${year}}${,
+  publisher = {${publisher}}}${,
+  volumes   = {${volumes}}}${,
+  series    = {${series}}}${,
+  type      = {${type}}}${,
+  chapter   = {${chapter}}}${,
+  pages     = {${pages}}}${,
+  address   = {${address}}}${,
+  edition   = {${edition}}}${,
+  month     = {${month}}}${,
+  note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/mvproceedings
+++ b/snippets/bibtex-mode/mvproceedings
@@ -1,0 +1,19 @@
+# -*- mode: snippet -*-
+# name: proceedings
+# key: proceedings
+# author: Spenser Truex
+# --
+@mvproceedings{ ${title},
+title        = {${title}},
+year         = {${year}}${,
+editor       = {${editor}}}${,
+volume       = {${volume}}}${,
+series       = {${series}}}${,
+address      = {${address}}}${,
+month        = {${month}}}${,
+organization = {${organization}}}${,
+publisher    = {${publisher}}}${,
+note         = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/mvreference
+++ b/snippets/bibtex-mode/mvreference
@@ -1,0 +1,22 @@
+# -*- mode: snippet -*-
+# name: mvereference
+# key: mvreference
+# author: Spenser Truex
+# --
+@mvreference{ ${title},
+editor    = {${editor}},
+title     = {${title}},
+year      = {${year}}${,
+publisher = {${publisher}}}${,
+volumes   = {${volumes}}}${,
+series    = {${series}}}${,
+type      = {${type}}}${,
+chapter   = {${chapter}}}${,
+pages     = {${pages}}}${,
+address   = {${address}}}${,
+edition   = {${edition}}}${,
+month     = {${month}}}${,
+note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/online
+++ b/snippets/bibtex-mode/online
@@ -1,0 +1,14 @@
+# -*- mode: snippet -*-
+# name: online
+# key: online
+# author: Spenser Truex
+# --
+@online{ ${title},
+  author  = {${author}},
+  title   = {${title}},
+  year    = {${year}},
+  url     = {${url}}${,
+  editor  = {${editor}}}${,
+  urldate = {${urldate}}}${,
+  note    = {${note}}}
+}

--- a/snippets/bibtex-mode/patent
+++ b/snippets/bibtex-mode/patent
@@ -1,0 +1,15 @@
+# -*- mode: snippet -*-
+# name: patent
+# key: patent
+# author: Spenser Truex
+# --
+@patent{ ${title},
+  title  = {${title}},
+  author = {${author}},
+  number = {${number}},
+  year   = {${year}},
+  holder = {${holder}}${,
+  type   = {${type}}}${,
+  url    = {${url}}}${,
+  note   = {${note}}}
+}

--- a/snippets/bibtex-mode/periodical
+++ b/snippets/bibtex-mode/periodical
@@ -1,0 +1,16 @@
+# -*- mode: snippet -*-
+# name: periodical
+# key: periodical
+# author: Spenser Truex
+# --
+@periodical{ ${title}
+editor     = {${editor}},
+title      = {${title}},
+year       = {${year}}${,
+issue      = {${issue}}}${,
+issuetitle = {${issuetitle}}}${,
+url        = {${url}}}${,
+urldate    = {${urldate}}}${,
+issn       = {${issn}}}${,
+note       = {${note}}}
+}

--- a/snippets/bibtex-mode/reference
+++ b/snippets/bibtex-mode/reference
@@ -1,0 +1,22 @@
+# -*- mode: snippet -*-
+# name: reference
+# key: reference
+# author: Spenser Truex
+# --
+@reference{ ${title},
+editor    = {${editor}},
+title     = {${title}},
+year      = {${year}}${,
+publisher = {${publisher}}}${,
+volume    = {${volume}}}${,
+series    = {${series}}}${,
+type      = {${type}}}${,
+chapter   = {${chapter}}}${,
+pages     = {${pages}}}${,
+address   = {${address}}}${,
+edition   = {${edition}}}${,
+month     = {${month}}}${,
+note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/report
+++ b/snippets/bibtex-mode/report
@@ -1,0 +1,17 @@
+# -*- mode: snippet -*-
+# name: report
+# key: report
+# author: Spenser Truex
+# --
+@report{ ${title},
+  author       = {${author}},
+  title        = {${title}},
+  institution  = {${institution}},
+  year         = {${year}},
+  type         = {${type}}${,
+  address      = {${address}}}${,
+  month        = {${month}}}${,
+  note         = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/set
+++ b/snippets/bibtex-mode/set
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: set
+# key: set
+# author: Spenser Truex
+# --
+@set{${title},
+  entryset = {${entryset}}
+}

--- a/snippets/bibtex-mode/software
+++ b/snippets/bibtex-mode/software
@@ -1,0 +1,14 @@
+# -*- mode: snippet -*-
+# name: software
+# key: software
+# --
+@software{ ${title}${,
+author       = {${author}}}${,
+title        = {${title}}}${,
+howpublished = {${howpublished}}}${,
+month        = {${month}}}${,
+year         = {${year}}}${,
+note         = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/suppbook
+++ b/snippets/bibtex-mode/suppbook
@@ -1,0 +1,22 @@
+# -*- mode: snippet -*-
+# name: suppbook
+# key: suppbook
+# author: Spenser Truex
+# --
+@suppbook{ ${title},
+author    = {${author}},
+title     = {${title}},
+chapter   = {${chapter}}${,
+pages     = {${pages}}},
+publisher = {${publisher}},
+year      = {${year}},
+volume    = {${volume}}${,
+series    = {${series}}}${,
+type      = {${type}}}${,
+address   = {${addre}ss}}${,
+edition   = {${edition}}}${,
+month     = {${month}}}${,
+note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/suppcollection
+++ b/snippets/bibtex-mode/suppcollection
@@ -1,0 +1,24 @@
+# -*- mode: snippet -*-
+# name: suppcollection
+# key: suppcollection
+# author: Spenser Truex
+# --
+@suppcollection{ ${title},
+author    = {${author}},
+title     = {${title}},
+booktitle = {${booktitle}},
+publisher = {${publisher}},
+year      = {${year}}${,
+editor    = {${editor}}}${,
+volume    = {${volume}}}${,
+series    = {${series}}}${,
+type      = {${type}}}${,
+chapter   = {${chapter}}}${,
+pages     = {${pages}}}${,
+address   = {${address}}}${,
+edition   = {${edition}}}${,
+month     = {${month}}}${,
+note      = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/suppperiodical
+++ b/snippets/bibtex-mode/suppperiodical
@@ -1,0 +1,18 @@
+# -*- mode: snippet -*-
+# name: suppperiodical
+# key: suppperiodical
+# author: Spenser Truex
+# --
+@suppperiodical{ ${title},
+author  = {${author}},
+title   = {${title}},
+journal = {${journal}},
+year    = {${year}}${,
+volume  = {${volume}}}${,
+number  = {${number}}}${,
+pages   = {${pages}}}${,
+month   = {${month}}}${,
+note    = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/thesis
+++ b/snippets/bibtex-mode/thesis
@@ -1,0 +1,17 @@
+# -*- mode: snippet -*-
+# name: thesis
+# key: thesis
+# author: Spenser Truex
+# --
+@thesis{ ${title},
+author  = {${author}},
+title   = {${title}},
+school  = {${school}},
+year    = {${year}}${,
+type    = {${type}}}${,
+address = {${address}}}${,
+month   = {${month}}}${,
+note    = {${note}}}
+}
+
+$0

--- a/snippets/bibtex-mode/xdata
+++ b/snippets/bibtex-mode/xdata
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: xdata
+# key: xdata
+# author: Spenser Truex
+# --
+@xdata{ ${title},
+  $0
+}


### PR DESCRIPTION
All of these snippets are defined in Section 2.1.1 "Regular Types" of the
[biblatex documentation](http://ctan.math.utah.edu/ctan/tex-archive/macros/latex/contrib/biblatex/doc/biblatex.pdf).

I'm also considering the following edits, I'd like to hear your opinion on including them:
- No space between the first `{` and the keyword (currently labeled `${title}`.
- Label that keyword `${key}` instead, since it is a keyword and not a title.

Thanks.