### PR TITLE
added \limits to bigcap and bigcap for latex-mode

### DIFF
--- a/snippets/latex-mode/bigcap
+++ b/snippets/latex-mode/bigcap
@@ -2,4 +2,4 @@
 # name: bigcap
 # key: bigcap
 # --
-\bigcap_{$1}^{$2}$0
+\bigcap\limits_{$1}^{$2}$0

--- a/snippets/latex-mode/bigcup
+++ b/snippets/latex-mode/bigcup
@@ -2,4 +2,4 @@
 # name: bigcup
 # key: bigcup
 # --
-\bigcup_{$1}^{$2}$0
+\bigcup\limits_{$1}^{$2}$0


### PR DESCRIPTION
Using \limits is standard practice and much more pleasant to the eye.