### PR TITLE
Added \limits to bigcap and bigcup for latex-mode

### DIFF
--- a/snippets/latex-mode/bigcap
+++ b/snippets/latex-mode/bigcap
@@ -2,4 +2,4 @@
 # name: bigcap
 # key: bigcap
 # --
-\bigcap_{$1}^{$2}$0
+\bigcap${1:\limits}_{$2}^{$3}$0

--- a/snippets/latex-mode/bigcup
+++ b/snippets/latex-mode/bigcup
@@ -2,4 +2,4 @@
 # name: bigcup
 # key: bigcup
 # --
-\bigcup_{$1}^{$2}$0
+\bigcup${1:\limits}_{$2}^{$3}$0


### PR DESCRIPTION
I've added the possibility to include \limits as a common alternative formatting option.