### PR TITLE
Fixed cout template token

### DIFF
--- a/snippets/c++-mode/cout
+++ b/snippets/c++-mode/cout
@@ -5,4 +5,4 @@
 # --
 `(progn (goto-char (point-min)) (unless (re-search-forward
 "^using\\s-+namespace std;" nil 'no-errer) "std::"))
-`cout << $0${1: << "${2:\n}"};
+`cout << $0${1:} << "${2:\n}";


### PR DESCRIPTION
The first and the second token of the cout template are merged, which is annoying when inserting cout and then typing, the second token `<< \n\` will be removed. This fix separates the second token from the first, so after inserting cout template, the user will be typing directly into the body of the cout.