### PR TITLE
Drop dependency of "s" library

### DIFF
--- a/snippets/rjsx-mode/.yas-setup.el
+++ b/snippets/rjsx-mode/.yas-setup.el
@@ -5,7 +5,6 @@
 ;;; Code:
 
 (require 'yasnippet)
-(require 's)
 
 (defun yas-jsx-get-class-name-by-file-name ()
   "Return name of class-like construct by `file-name'."
@@ -17,5 +16,9 @@
              (directory-file-name (file-name-directory buffer-file-name)))
           class-name))
     ""))
+
+(defun yas-snake-case (s)
+  "Convert S to snake-case."
+  (mapconcat #'upcase (split-string s "[^[:word:]0-9]+" t) "_"))
 
 ;;; .yas-setup.el ends here

--- a/snippets/rjsx-mode/Redux/rxaction
+++ b/snippets/rjsx-mode/Redux/rxaction
@@ -6,6 +6,6 @@
 # --
 
 export const ${1:actionName} = (payload) => ({
-  type: ${1:$((upcase (s-snake-case yas-text)))},
+  type: ${1:$((yas-snake-case yas-text))},
   payload
 })

--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -5,7 +5,7 @@
 ;; Author: Andrea Crotti <andrea.crotti.0@gmail.com>
 ;; Keywords: snippets
 ;; Version: 0.2
-;; Package-Requires: ((yasnippet "0.8.0") (s "1.12.0"))
+;; Package-Requires: ((yasnippet "0.8.0"))
 ;; Keywords: convenience, snippets
 
 ;;; Commentary:


### PR DESCRIPTION
Hi,

I was cleaning up my package and dependency list, when I noticed that in my case I had the "s" library installed just because of this package. When I looked into where it was being used, I noticed it seems like the only place where was used was in a Redux snippet introduced in f52190f3e4d3b8359cfae7ebb6b6328f47fbfbd5. This patch should keep the functionality, while dropping the dependency.