### PR TITLE
cc-mode/if: escape backslashes

### DIFF
--- a/snippets/cc-mode/if
+++ b/snippets/cc-mode/if
@@ -2,6 +2,6 @@
 # name: if (...) { ... }
 # key: if
 # --
-if (${1:condition}) ${2:{
+if (${1:condition}) ${2:\{
     $0
-}}
+\}}


### PR DESCRIPTION
Escaping lets the user choose between writing an unbraced `if` by
pressing `C-d`, or continue with a braced `if` by pressing TAB.
Without this patch, pressing `C-d` leaves an unbalanced right brace.