### PR TITLE
Fix leftover curly brace during expansion in various print snippets

### DIFF
--- a/snippets/rust-mode/eprint
+++ b/snippets/rust-mode/eprint
@@ -2,4 +2,4 @@
 # name: eprint!("{}", value);
 # key: eprint
 # --
-eprint!("${1:{}}", $2);
+eprint!("${1:{\}}", $2);

--- a/snippets/rust-mode/eprintln
+++ b/snippets/rust-mode/eprintln
@@ -2,4 +2,4 @@
 # name: eprintln!("{}", value);
 # key: eprintln
 # --
-eprintln!("${1:{}}", $2);
+eprintln!("${1:{\}}", $2);

--- a/snippets/rust-mode/print
+++ b/snippets/rust-mode/print
@@ -2,4 +2,4 @@
 # name: print!("{}", value);
 # key: print
 # --
-print!("${1:{}}", $2);
+print!("${1:{\}}", $2);

--- a/snippets/rust-mode/println
+++ b/snippets/rust-mode/println
@@ -2,4 +2,4 @@
 # name: println!("{}", value);
 # key: println
 # --
-println!("${1:{}}", $2);
+println!("${1:{\}}", $2);


### PR DESCRIPTION
Right curly brace is leftover upon typing at first tabstop of print,
println, eprint and eprintln.

This commit will ensure that the right curly brace will also be
replaced upon typing at the tabstop.