### PR TITLE
current-date in fundamental-mode

### DIFF
--- a/snippets/fundamental-mode/current-date
+++ b/snippets/fundamental-mode/current-date
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# name: current-date
+# key: dd
+# contributor : Kristof Molnar-Tatai <kristof.mlnr@gmail.com>
+# --
+`(format-time-string "%Y-%m-%d")`


### PR DESCRIPTION
Inspired by [Karl Voit's](https://github.com/novoid) [blog
post](https://karl-voit.at/2016/12/18/org-depend/). It simply inserts
the current date in YYYY-MM-DD bound to 'dd'

Found no conflict with other bindigs.