### PR TITLE
Fix console.log (formatted version)

### DIFF
--- a/snippets/js-mode/console/clo
+++ b/snippets/js-mode/console/clo
@@ -1,9 +1,7 @@
 # -*- mode: snippet -*-
-# uuid: 3d2ddcac-d8c0-4b56-81a7-523eb6621442
-# contributor: Jimmy Yuen Ho Wong <wyuenho@gmail.com>
 # name: console.log (formatted)
 # key: clo
 # group: console
 # --
 
-console.log('${1:object}', ${1:object})
+console.log('$1: ', ${1:object})


### PR DESCRIPTION
Fixes the behavior of a placeholder for formatted console.log.

Steps to reproduce:
1. hit `clo` and expand the snippet in a JS file.
2. start typing the object to inspect

Actual:
only the second` console.log` argument is changed

Expected:
first argument (a label) should match the object name.