### PR TITLE
Fix snippet nfn third argument

### DIFF
--- a/snippets/js-mode/nfn
+++ b/snippets/js-mode/nfn
@@ -6,5 +6,5 @@
 # --
 
 const ${1:name} = (${2:params}) => {
-  ${3}
+  ${3:body}
 }


### PR DESCRIPTION
It was printing value `3`, now it receives the correct third argument.