### PR TITLE
python-mode: Fix a byte compilation warning in .yas-setup.el.

### DIFF
--- a/snippets/python-mode/.yas-setup.el
+++ b/snippets/python-mode/.yas-setup.el
@@ -1,4 +1,5 @@
 (require 'yasnippet)
+(require 'yasnippet-snippets)
 (defvar yas-text)
 
 (defun python-split-args (arg-string)


### PR DESCRIPTION
This fixes the following byte compilation warning:

    Compiling [...]/snippets/python-mode/.yas-setup.el...

    In end of data:
    snippets/python-mode/.yas-setup.el:39:1:Warning: the function
        ‘yasnippet-snippets--fixed-indent’ is not known to be defined.