### PR TITLE
js-mode: Add new error constructor

### DIFF
--- a/snippets/js-mode/error
+++ b/snippets/js-mode/error
@@ -1,0 +1,5 @@
+# -*- mode: snippet; require-final-newline: nil -*-
+# name: new error
+# key: err
+# --
+new Error(${1:message});


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error

----

Personally, I'd use `throw new Error` more often, but I thought this might be more broadly useful.

I've not updated the big html file, since it seems that hasn't been edited in a while?