### PR TITLE
Modernize nix-mode/package_github snippet

### DIFF
--- a/snippets/nix-mode/package_github
+++ b/snippets/nix-mode/package_github
@@ -3,8 +3,9 @@
 # key: pg
 # --
 { stdenv, fetchFromGitHub$1 }:
+
 stdenv.mkDerivation rec {
-  name = "$2-\$\{version\}";
+  pname = "$2";
   version = "$3";
 
   src = fetchFromGitHub {
@@ -14,36 +15,46 @@ stdenv.mkDerivation rec {
     sha256 = "$6";
   };
 
-  buildInputs = [ $1];
+  buildInputs = [ $1 ];
 
-  meta = {
+  meta = with stdenv.lib; {
     description = "$7";
-    homepage = https://${8:github.com/$4/$2};
+    homepage = "https://${8:github.com/$4/$2}";
 
-    license = stdenv.lib.licenses.${9:$$
+    license = licenses.${9:$$
   (yas-choose-value '(
-    "agpl3"
-    "asl20"
-    "bsd2"
-    "bsd3"
-    "gpl2"
-    "gpl3"
-    "lgpl3"
-    "mit"
+  "asl20"
+  "bsd2"
+  "bsd3"
+  "free"
+  "gpl2Only"
+  "gpl2Plus"
+  "gpl3Only"
+  "gpl3Plus"
+  "isc"
+  "lgpl21Only"
+  "lgpl21Plus"
+  "lgpl2Only"
+  "lgpl2Plus"
+  "lgpl3Only"
+  "mit"
+  "mpl20"
+  "ofl"
+  "unfree"
   ))};
-    maintainers = [ stdenv.lib.maintainers.$10 ];
-    platforms = stdenv.lib.platforms.${11:$$
+    maintainers = with maintainers; [ $10 ];
+    platforms = platforms.${11:$$
   (yas-choose-value '(
-  "gnu"
   "linux"
+  "unix"
+  "all"
   "darwin"
+  "gnu"
   "freebsd"
   "openbsd"
   "netbsd"
   "cygwin"
   "illumos"
-  "unix"
-  "all"
   "none"
   "allBut"
   "mesaPlatforms"


### PR DESCRIPTION
- URLs should be quoted
- name+version -> pname+version, remove string interpolation
- update license list based on data analysis (covers over 90% of licenses found in Nixpkgs)
- rearrange platform list based more on frequency

Breakdown of most common licenses
```
    104 mpl20
    106 lgpl2Only
    113 ofl
    122 lgpl3Only
    137 lgpl2Plus
    139 isc
    153 free
    198 lgpl21Plus
    276 lgpl21Only
    301 bsd2
    326 unfree
    602 gpl3Plus
    754 bsd3
    868 asl20
    937 gpl2Plus
   1079 gpl3Only
   1712 mit
   1744 gpl2Only

# 9671/10671
# covers 90.6% of licenses
```