### PR TITLE
Add clojure-mode expansion for a Rich comment

### DIFF
--- a/snippets/clojure-mode/rc
+++ b/snippets/clojure-mode/rc
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: rich comment
+# key: rc
+# --
+(comment
+  $0$>
+  ,)$>


### PR DESCRIPTION
- The trailing comma keeps paredit/parinfer from collapsing lines