### PR TITLE
Update header snippet in emacs-lisp-mode

### DIFF
--- a/snippets/emacs-lisp-mode/header
+++ b/snippets/emacs-lisp-mode/header
@@ -15,18 +15,18 @@
 ${9:
 ;; This file is not part of GNU Emacs
 
-;; This file is free software; you can redistribute it and/or modify
+;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 3, or (at your option)
-;; any later version.
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
 
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
 
-;; For a full copy of the GNU General Public License
-;; see <http://www.gnu.org/licenses/>.
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 }
 
 ;;; Commentary:


### PR DESCRIPTION
According to the license text on [gnu], I found this snippet had wrong
punctuation and missed some words.

I think it's better to keep in line with the official website. At least, we
should use `https` instead of `http` for safety.

[gnu]: https://www.gnu.org/licenses/gpl-3.0.html