### PR TITLE
Add js-mode to web mode snippets by default

### DIFF
--- a/snippets/web-mode/.yas-parents
+++ b/snippets/web-mode/.yas-parents
@@ -1,1 +1,2 @@
 html-mode
+js-mode


### PR DESCRIPTION
JavaScript snippets should be enabled in web mode by default. People who use web mode do so because they use multiple languages. I think it's quite reasonable to say that it is highly likely that people working with HTML are using JavaScript, and therefore they should be on without any additional config.