### PR TITLE
snippets/go-mode: add more useful template for test-snippet

### DIFF
--- a/snippets/go-mode/test
+++ b/snippets/go-mode/test
@@ -3,6 +3,38 @@
 # key: at
 # contributor : @atotto
 # --
-func Test$1(t *testing.T) {
-	$0
+func Test${1:Feature}(t *testing.T) {
+	${0:// a test case consists of a @name, an @input, an @expected and
+	// an @exec func}
+
+	cases := []struct {
+	      name     string
+	      disable  bool
+	      input    interface{}
+	      expected interface{}
+	      exec     func(input interface{}) interface{}
+	}{
+		{
+			name: "test case for ...",
+			input: nil,
+			expected: nil,
+			exec: func(input interface{}) interface{} {
+			      return nil
+			},
+		},
+	}
+
+	for _, c := range cases {
+	    if c.disable {
+	       continue
+	    }
+
+	    test := c
+	    t.Run(test.name, func(t *testing.T) {
+	        got := test.exec(test.input)
+		if got != test.expected {
+		   t.Fatalf("expected: \`%v\`, got: \`%v\`\n", test.expected, got)
+		}
+	    })
+	}
 }

--- a/snippets/go-mode/test
+++ b/snippets/go-mode/test
@@ -1,6 +1,6 @@
 # -*- mode: snippet -*-
 # name: test
-# key: at
+# key: test
 # contributor : @atotto
 # --
 func Test${1:Feature}(t *testing.T) {


### PR DESCRIPTION
Hi,  this commit add a more useful template for test-snippet in go-mode