### PR TITLE
fix: escape bracket inside snippet

### DIFF
--- a/snippets/js-mode/class
+++ b/snippets/js-mode/class
@@ -6,7 +6,7 @@ class ${1:Class}${2: extends ${3:ParentClass}} {
   ${4:constructor(${5:arg}) {
     ${6:super(arg);}
     $7
-  }}
+  \}}
 
   $0
 }


### PR DESCRIPTION
### The problem

This snippet has `{ }` at the constructor step but is not escaped:


#### before escaping:
<img width="388" alt="Screen Shot 2021-08-07 at 17 24 54" src="https://user-images.githubusercontent.com/11412209/128613051-55b5dc7a-8bf8-4cfa-8113-2972d1d98593.png">

#### after escaping:

<img width="418" alt="Screen Shot 2021-08-07 at 17 25 52" src="https://user-images.githubusercontent.com/11412209/128613067-c6d333c1-342e-4311-8f4c-198b9366a734.png">
