### PR TITLE
dockerfile-mode: add 'dockerfile-image-name' local file variable

### DIFF
--- a/snippets/dockerfile-mode/dockerfile-image-name
+++ b/snippets/dockerfile-mode/dockerfile-image-name
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: dockerfile-image-name
+# key: dockerfile-image-name
+# --
+## -*- dockerfile-image-name: "$1" -*-


### PR DESCRIPTION
As per Readme for dockerfile-mode.
Notice I'm not using obsolete `docker-image-name`, but `dockerfile-image-name`. See spotify/dockerfile-mode#68.