### PR TITLE
Update snippet dir after modifying it

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -50,6 +50,7 @@
   ;; value, so that yasnippet will automatically find the directory
   ;; after this package is updated (i.e., moves directory).
   (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
+  (yas--load-snippet-dirs)
   (yas-load-directory yasnippet-snippets-dir t))
 
 (defgroup yasnippet-snippets nil


### PR DESCRIPTION
It seems like without this line; you would always have to call `yas-reload-all` in your configuration? This should lower your Emacs' start up time if you have a tone of snippets to load.