### PR TITLE
Fix: do NOT overwrite user snippets

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -50,8 +50,7 @@
   ;; value, so that yasnippet will automatically find the directory
   ;; after this package is updated (i.e., moves directory).
   (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
-  (yas--load-snippet-dirs)
-  (yas-load-directory yasnippet-snippets-dir t))
+  (yas--load-snippet-dirs))
 
 (defgroup yasnippet-snippets nil
   "Options for yasnippet setups.


### PR DESCRIPTION
When have the same snippet name with same mode, prefer user snippet.

"yas--load-snippet-dirs" loads "(yas-snippet-dirs)" with reverse
order, which loads "yasnippet-snippets-dir" first with JIT