### PR TITLE
Fixes try-src-prefix definition is void

### DIFF
--- a/snippets/clojure-mode/ns
+++ b/snippets/clojure-mode/ns
@@ -11,13 +11,13 @@
 		    nil))))
        (let* ((p (buffer-file-name))
 	      (p2 (cl-first
-		   (cl-remove-if-not '(lambda (x) x)
+		   (cl-remove-if-not #'(lambda (x) x)
 				     (mapcar
-				      '(lambda (pfx)
+				      #'(lambda (pfx)
 					 (try-src-prefix p pfx))
 				      '("/src/cljs/" "/src/clj/" "/src/" "/test/")))))
 	      (p3 (file-name-sans-extension p2))
-	      (p4 (mapconcat '(lambda (x) x)
+	      (p4 (mapconcat #'(lambda (x) x)
 			     (split-string p3 "/")
 			     ".")))
 	 (replace-regexp-in-string "_" "-" p4)))`)


### PR DESCRIPTION
Fixes Clojure `ns` snippet.

Original behavior yields
```clojure
(ns Symbol’s function definition is void: try-src-prefix)
```
Found and fixed in:
GNU Emacs 28.2 (build 1, x86_64-apple-darwin18.7.0, NS appkit-1671.60 Version 10.14.6 (Build 18G95)) of 2022-09-12