### PR TITLE
*yasnippet-snippets.el: avoid duplicate loading on initialize the snippets

### DIFF
--- a/yasnippet-snippets.el
+++ b/yasnippet-snippets.el
@@ -49,8 +49,9 @@
   ;; NOTE: we add the symbol `yasnippet-snippets-dir' rather than its
   ;; value, so that yasnippet will automatically find the directory
   ;; after this package is updated (i.e., moves directory).
-  (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
-  (yas--load-snippet-dirs))
+  (unless (member 'yasnippet-snippets-dir yas-snippet-dirs)
+    (add-to-list 'yas-snippet-dirs 'yasnippet-snippets-dir t)
+    (yas--load-snippet-dirs)))
 
 (defgroup yasnippet-snippets nil
   "Options for yasnippet setups.


### PR DESCRIPTION
Hi,

The `(yasnippet-snippets-initialize)` will be called twice for the `yasnippet-snippets` installed by `package.el`.
It happened for the `eval-after-load` is marked as `;;;autoload`, it will appear in the file `yasnippet-snippets-autoloads.el` which is generated by the `package,el`, then the function will be called in the autoloads file and the main file.
https://github.com/AndreaCrotti/yasnippet-snippets/blob/8e4c521252501dd9ad71ea78fae14683ab7a14cb/yasnippet-snippets.el#L73-L75

This change will detect the duplicate call and ignore it.
Please help review and merge the the patch. Thanks.