### PR TITLE
very pedantic spelling correction

### DIFF
--- a/snippets/org-mode/video
+++ b/snippets/org-mode/video
@@ -3,4 +3,4 @@
 # key: <vi
 # --
 
-[[${1:link of the video}][file:${2:link of the image}]
+[[${1:link to the video}][file:${2:link of the image}]


### PR DESCRIPTION
I believe a more correct way of phrasing this is "link to the video/image" instead of "link of the video/image". Sorry for the (possibly incorrect) correction. I just noticed it while browsing snippets and it sounded wrong.