### PR TITLE
Latex math mode snippets

### DIFF
--- a/snippets/latex-mode/corollary
+++ b/snippets/latex-mode/corollary
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: corollary
+# key: corr
+# --
+\begin{cor}[${2:title}]
+  \label{cor:${1:label}}
+  $0
+\end{cor}

--- a/snippets/latex-mode/lemma
+++ b/snippets/latex-mode/lemma
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: lemma
+# key: lem
+# --
+\begin{lem}[${2:title}]
+  \label{lem:${1:label}}
+  $0
+\end{lem}

--- a/snippets/latex-mode/theorem
+++ b/snippets/latex-mode/theorem
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: theorem
+# key: thm
+# --
+\begin{thm}[${2:title}]
+  \label{thm:${1:label}}
+  $0
+\end{thm}


### PR DESCRIPTION
Added snippets for standard latex mode environments often used when writing in math mode.

Includes Theorem, Lemma and Corollary environment snippets that automatically asks for a label tag and title before dropping the cursor into the environment.