### PR TITLE
Add async versions of function snippets for rust

### DIFF
--- a/snippets/rust-mode/afn
+++ b/snippets/rust-mode/afn
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: async fn name() { ... }
+# key: afn
+# --
+async fn ${1:name}($2) {
+    $0
+}

--- a/snippets/rust-mode/afnr
+++ b/snippets/rust-mode/afnr
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: async fn name() -> Type { ... }
+# key: afnr
+# --
+async fn ${1:name}($2) -> ${3:Type} {
+    $0
+}

--- a/snippets/rust-mode/afns
+++ b/snippets/rust-mode/afns
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: async fn name(&self) -> Type  { ... }
+# key: afns
+# --
+async fn ${1:name}(${2:&self}) -> ${3:Type}  {
+    $0
+}

--- a/snippets/rust-mode/afnw
+++ b/snippets/rust-mode/afnw
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: async fn name<T>(x: T) where T: Clone { ... }
+# key: afnw
+# --
+async fn ${1:name}<${2:T}>(${3:x: T}) where ${4:T: Clone} {
+    $0
+}

--- a/snippets/rust-mode/pafn
+++ b/snippets/rust-mode/pafn
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: pub async fn name() { ... }
+# key: pafn
+# --
+pub async fn ${1:name}($2) {
+    $0
+}

--- a/snippets/rust-mode/pafnr
+++ b/snippets/rust-mode/pafnr
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: pub async fn name() -> Type { ... }
+# key: pafnr
+# --
+pub async fn ${1:name}($2) -> ${3:Type} {
+    $0
+}

--- a/snippets/rust-mode/pafns
+++ b/snippets/rust-mode/pafns
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: pub async fn name(&self) -> Type  { ... }
+# key: pafns
+# --
+pub async fn ${1:name}(${2:&self}) -> ${3:Type} {
+    $0
+}

--- a/snippets/rust-mode/pafnw
+++ b/snippets/rust-mode/pafnw
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: pub async fn name<T>(x: T) where T: Clone { ... }
+# key: pafnw
+# --
+pub async fn ${1:name}<${2:T}>(${3:x: T}) where ${4:T: Clone} {
+    $0
+}


### PR DESCRIPTION
Same as the existing function snippets, just with the async keyword, all prefixed with a.