### PR TITLE
ENH: python-mode/with-open

### DIFF
--- a/snippets/python-mode/with-open
+++ b/snippets/python-mode/with-open
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: with-open
+# key: wo
+# group : control structure
+# contributor: Quazgar
+# --
+with open(${1:"filename"}${2:, encoding="${3:utf-8}"}${4:, mode="${5:w}"}) as ${6:myfile}:
+    $0


### PR DESCRIPTION
New snippet for python-mode: `wo` expands to

```py
with open("filename", encoding="utf-8", mode="w") as my_file:
  do_something
```