### PR TITLE
Make metadata section conform to existing directives

### DIFF
--- a/snippets/bibtex-mode/bookinbook
+++ b/snippets/bibtex-mode/bookinbook
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: bookinbook
 # key: bookinbook
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @bookinbook{ ${title},
 author    = {${author}},

--- a/snippets/bibtex-mode/collection
+++ b/snippets/bibtex-mode/collection
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: collection
 # key: collection
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @collection{ ${title},
   editor    = {${editor}},

--- a/snippets/bibtex-mode/dataset
+++ b/snippets/bibtex-mode/dataset
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: dataset
 # key: dataset
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @dataset{ ${title}
   title        = {${title}},

--- a/snippets/bibtex-mode/electronic
+++ b/snippets/bibtex-mode/electronic
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: electronic
 # key: electronic
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @electronic{ ${title},
 author  = {${author}},

--- a/snippets/bibtex-mode/inreference
+++ b/snippets/bibtex-mode/inreference
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: inreference
 # key: inreference
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @inreference{ ${title},
 author    = {${author}},

--- a/snippets/bibtex-mode/mvbook
+++ b/snippets/bibtex-mode/mvbook
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: mvbook
 # key: mvbook
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @mvbook{ ${title},
   author    = {${author}},

--- a/snippets/bibtex-mode/mvcollection
+++ b/snippets/bibtex-mode/mvcollection
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: mvcollection
 # key: mvcollection
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @mvcollection{ ${title},
   editor    = {${editor}},

--- a/snippets/bibtex-mode/mvreference
+++ b/snippets/bibtex-mode/mvreference
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: mvereference
 # key: mvreference
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @mvreference{ ${title},
 editor    = {${editor}},

--- a/snippets/bibtex-mode/online
+++ b/snippets/bibtex-mode/online
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: online
 # key: online
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @online{ ${title},
   author  = {${author}},

--- a/snippets/bibtex-mode/patent
+++ b/snippets/bibtex-mode/patent
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: patent
 # key: patent
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @patent{ ${title},
   title  = {${title}},

--- a/snippets/bibtex-mode/periodical
+++ b/snippets/bibtex-mode/periodical
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: periodical
 # key: periodical
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @periodical{ ${title}
 editor     = {${editor}},

--- a/snippets/bibtex-mode/reference
+++ b/snippets/bibtex-mode/reference
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: reference
 # key: reference
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @reference{ ${title},
 editor    = {${editor}},

--- a/snippets/bibtex-mode/report
+++ b/snippets/bibtex-mode/report
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: report
 # key: report
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @report{ ${title},
   author       = {${author}},

--- a/snippets/bibtex-mode/set
+++ b/snippets/bibtex-mode/set
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: set
 # key: set
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @set{${title},
   entryset = {${entryset}}

--- a/snippets/bibtex-mode/suppbook
+++ b/snippets/bibtex-mode/suppbook
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: suppbook
 # key: suppbook
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @suppbook{ ${title},
 author    = {${author}},

--- a/snippets/bibtex-mode/suppcollection
+++ b/snippets/bibtex-mode/suppcollection
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: suppcollection
 # key: suppcollection
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @suppcollection{ ${title},
 author    = {${author}},

--- a/snippets/bibtex-mode/suppperiodical
+++ b/snippets/bibtex-mode/suppperiodical
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: suppperiodical
 # key: suppperiodical
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @suppperiodical{ ${title},
 author  = {${author}},

--- a/snippets/bibtex-mode/thesis
+++ b/snippets/bibtex-mode/thesis
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: thesis
 # key: thesis
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @thesis{ ${title},
 author  = {${author}},

--- a/snippets/bibtex-mode/xdata
+++ b/snippets/bibtex-mode/xdata
@@ -1,7 +1,7 @@
 # -*- mode: snippet -*-
 # name: xdata
 # key: xdata
-# author: Spenser Truex
+# contributor: Spenser Truex
 # --
 @xdata{ ${title},
   $0

--- a/snippets/scala-mode/app
+++ b/snippets/scala-mode/app
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Anders Bach Nielsen <andersbach.nielsen@epfl.ch>
+# contributor: Anders Bach Nielsen <andersbach.nielsen@epfl.ch>
 # name: object name extends App
 # key: app
 # --

--- a/snippets/scala-mode/case
+++ b/snippets/scala-mode/case
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: case pattern =>
 # key: case
 # --

--- a/snippets/scala-mode/cc
+++ b/snippets/scala-mode/cc
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Sam Halliday
+# contributor: Sam Halliday
 # name: case class T(arg: A)
 # key: cc
 # --

--- a/snippets/scala-mode/co
+++ b/snippets/scala-mode/co
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: case object T
 # key: co
 # --

--- a/snippets/scala-mode/cons
+++ b/snippets/scala-mode/cons
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: element1 :: element2
 # key: cons
 # --

--- a/snippets/scala-mode/def
+++ b/snippets/scala-mode/def
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: def f(arg: T): R = {...}
 # key: def
 # --

--- a/snippets/scala-mode/doc
+++ b/snippets/scala-mode/doc
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Anders Bach Nielsen <andersbach.nielsen@epfl.ch>
+# contributor: Anders Bach Nielsen <andersbach.nielsen@epfl.ch>
 # name: /** ... */
 # key: doc
 # --

--- a/snippets/scala-mode/for
+++ b/snippets/scala-mode/for
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Sam Halliday
+# contributor: Sam Halliday
 # name: for { x <- xs } yield
 # key: for
 # --

--- a/snippets/scala-mode/if
+++ b/snippets/scala-mode/if
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: if (cond) { .. }
 # key: if
 # --

--- a/snippets/scala-mode/ls
+++ b/snippets/scala-mode/ls
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: List(..)
 # key: ls
 # --

--- a/snippets/scala-mode/main
+++ b/snippets/scala-mode/main
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: def main(args: Array[String]) = { ... }
 # key: main
 # --

--- a/snippets/scala-mode/match
+++ b/snippets/scala-mode/match
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: cc match { .. }
 # key: match
 # --

--- a/snippets/scala-mode/ob
+++ b/snippets/scala-mode/ob
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: object name extends T
 # key: ob
 # --

--- a/snippets/scala-mode/throw
+++ b/snippets/scala-mode/throw
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Jonas Bonèr <jonas@jonasboner.com>
+# contributor: Jonas Bonèr <jonas@jonasboner.com>
 # name: throw new Exception
 # key: throw
 # --

--- a/snippets/scala-mode/try
+++ b/snippets/scala-mode/try
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-#Author : Sam Halliday
+# contributor: Sam Halliday
 # name: try { .. } catch { case e => ..}
 # key: try
 # --

--- a/snippets/scala-mode/valueclass
+++ b/snippets/scala-mode/valueclass
@@ -1,5 +1,5 @@
 # -*- mode: snippet -*-
-# Author: Michael Pollmeier
+# contributor: Michael Pollmeier
 # name: value class
 # key: vc
 # --


### PR DESCRIPTION
When snippets are loaded or reloaded, lots of warnings are logged to the messages buffer. This pull request fixes the subset of warnings caused by the use of ‘author’ instead of ‘contributor’; only the latter is a [valid directive](https://joaotavora.github.io/yasnippet/snippet-development.html#org5e87ae3).