### PR TITLE
Add declare(strict_types=1); to PHP instead of ticks

### DIFF
--- a/snippets/php-mode/strict-types
+++ b/snippets/php-mode/strict-types
@@ -1,0 +1,7 @@
+-# -*- mode: snippet -*-
+-# contributor: USAMI Kenta <tadsan@zonu.me>
+-# name: declare(strict_types=1)
+-# key: strict_types
+-# group: definitions
+-# --
+declare(strict_types=1);

--- a/snippets/php-mode/ticks
+++ b/snippets/php-mode/ticks
@@ -1,7 +1,0 @@
-# -*- mode: snippet -*-
-# contributor: USAMI Kenta <tadsan@zonu.me>
-# name: declare(ticks=)
-# key: ticks
-# group: definitions
-# --
-declare(ticks=${1:1});


### PR DESCRIPTION
In modern PHP code `declare(strict_types=1);` can appear in almost every file, but very few `ticks`.

Although these are separate feature from each other, it makes sense to remove `ticks` since the `declare` keyword is in conflict.