### PR TITLE
feat: links tsx-ts, markdown-ts and typescriptreact-mode

### DIFF
--- a/snippets/markdown-ts-mode/.yas-parents
+++ b/snippets/markdown-ts-mode/.yas-parents
@@ -1,0 +1,1 @@
+markdown-mode

--- a/snippets/tsx-ts-mode/.yas-parents
+++ b/snippets/tsx-ts-mode/.yas-parents
@@ -1,0 +1,1 @@
+typescript-mode

--- a/snippets/typescriptreact-mode/.yas-parents
+++ b/snippets/typescriptreact-mode/.yas-parents
@@ -1,0 +1,1 @@
+typescript-mode


### PR DESCRIPTION
Hello there @AndreaCrotti !

Just some "redirections" to parents with newer modes:

The new `markdown-ts-mode` on MELPA: https://github.com/LionyxML/markdown-ts-mode

The `tsx-ts-mode`, since typescript with jsx inside it is now a separated mode.

The `typescriptreact-mode`, as a well spread fix around typescript world (see https://github.com/joaotavora/eglot/issues/624).

