### PR TITLE
Fix php-mode strict-types snippet

### DIFF
--- a/snippets/php-mode/strict-types
+++ b/snippets/php-mode/strict-types
@@ -1,7 +1,7 @@
--# -*- mode: snippet -*-
--# contributor: USAMI Kenta <tadsan@zonu.me>
--# name: declare(strict_types=1)
--# key: strict_types
--# group: definitions
--# --
+# -*- mode: snippet -*-
+# contributor: USAMI Kenta <tadsan@zonu.me>
+# name: declare(strict_types=1)
+# key: strict_types
+# group: definitions
+# --
 declare(strict_types=1);


### PR DESCRIPTION
I'm sorry, it snippet was not commented out because the header contains extra characters at the beginning of the line.

Fixes https://github.com/AndreaCrotti/yasnippet-snippets/pull/496