### PR TITLE
Remove directive formatting from NOTE marker

### DIFF
--- a/snippets/python-mode/function_docstring
+++ b/snippets/python-mode/function_docstring
@@ -2,7 +2,7 @@
 # name: function_docstring
 # key: fd
 # group: definitions
-# NOTE: Use minimum indentation, because Emacs 25+ doesn't dedent docstrings.
+# NOTE Use minimum indentation, because Emacs 25+ doesn't dedent docstrings.
 # --
 def ${1:name}($2):
  \"\"\"$3


### PR DESCRIPTION
Before this commit, this snippet formatted a NOTE marker as a snippet directive, as `NOTE:`. As `NOTE` isn't a directive, this triggered a directive warning.