### PR TITLE
python-mode: Adding missing __next__ special method.

### DIFF
--- a/snippets/python-mode/__next__
+++ b/snippets/python-mode/__next__
@@ -1,0 +1,7 @@
+# -*- mode: snippet -*-
+# name: __next__
+# key: _next
+# group: Special methods
+# --
+def __next__(self):
+    $0


### PR DESCRIPTION
Looks like there's not a lot of missing methods:

```
$ grep '^\.\. method:: [a-z]*\.__' ~/src/python/cpython/Doc/reference/datamodel.rst | cut -d. -f4 | cut -d '(' -f1| while read -r dunder; do if ! [[ -f "snippets/python-mode/$dunder" ]] ; then echo "Missing $dunder"; fi; done
Missing __mro_entries__
Missing __buffer__
Missing __release_buffer__
```

but `__next__` was not spotted by this grep... usage will tell us more hopefully :)