### PR TITLE
python-mode: __missing__ was missing its key argument.

### DIFF
--- a/snippets/python-mode/__missing__
+++ b/snippets/python-mode/__missing__
@@ -3,5 +3,5 @@
 # key: _missing
 # group: Special methods
 # --
-def __missing__(self):
+def __missing__(self, key):
     return $0


### PR DESCRIPTION
cf. https://docs.python.org/3/reference/datamodel.html#object.__missing__