### PR TITLE
Update reason-mode function snippet

### DIFF
--- a/snippets/reason-mode/function
+++ b/snippets/reason-mode/function
@@ -2,4 +2,4 @@
 # name: function
 # key: func
 # --
-(${1:paramters}) -> $0
+(${1:paramters}) => $0


### PR DESCRIPTION
Not sure if the syntax was historically something different, but [reason now](https://reasonml.github.io/docs/en/function#the-basics) uses `=>` rather than `->` for functions