### PR TITLE
prog-mode: Add snippets for SPDX-* comments

### DIFF
--- a/snippets/prog-mode/.yas-setup.el
+++ b/snippets/prog-mode/.yas-setup.el
@@ -29,6 +29,13 @@
   "This function returns `comment-start' trimmed by whitespaces."
   (yas-s-trim comment-start))
 
+(defun yas-trimmed-add-comment ()
+  "This function returns `comment-start' trimmed by whitespaces. It uses
+`comment-add' to determine how many comment symbols to insert."
+  (yas-s-trim (apply #'concat (mapcar (lambda (x)
+                                        comment-start)
+                                      (number-sequence 0 comment-add)))))
+
 (defun yas-trimmed-comment-end ()
   "This function returns `comment-end' trimmed by whitespaces if
 `comment-end' is not empty. Otherwise the reversed output of

--- a/snippets/prog-mode/spdxcopyright
+++ b/snippets/prog-mode/spdxcopyright
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# contributor: Antero Mejr <mail@antr.me>
+# name: spdxcopyright
+# key: spc
+# --
+`(yas-trimmed-add-comment)` SPDX-FileCopyrightText: $0`comment-end`

--- a/snippets/prog-mode/spdxlicense
+++ b/snippets/prog-mode/spdxlicense
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# contributor: Antero Mejr <mail@antr.me>
+# name: spdxlicense
+# key: spl
+# --
+`(yas-trimmed-add-comment)` SPDX-License-Identifier: $0`comment-end`


### PR DESCRIPTION
Adds snippets for SPDX comments, as described here:
https://spdx.dev/learn/handling-license-info/

The procedure yas-trimmed-add-comment was added because in lisp-derived modes, full-line comments start with `;;`, not `;`. So the `comment-add` variable should be taken into consideration.