### PR TITLE
Update js-mode "for" to keep up with modern JS syntax

### DIFF
--- a/snippets/js-mode/for
+++ b/snippets/js-mode/for
@@ -1,6 +1,6 @@
 # -*- mode: snippet; require-final-newline: nil -*-
 # name: for
 # --
-for (var ${1:i} = ${2:0}; $1 < ${3:collection}.length; $1++) {
+for (let ${1:i} = ${2:0}; $1 < ${3:collection}.length; $1++) {
   $0
 }


### PR DESCRIPTION
"let" contains the scope of the variable to the loop, while "var" always declares global scope.

Following up https://github.com/AndreaCrotti/yasnippet-snippets/pull/305