### PR TITLE
Create `nix-ts-mode` sub-directory; Add additional snippets to `nix-mode`

### DIFF
--- a/snippets/nix-mode/doCheck
+++ b/snippets/nix-mode/doCheck
@@ -1,0 +1,8 @@
+# -*- mode: snippet -*-
+# name: doCheck
+# key: dc
+# --
+doCheck = ${1:$$(yas-auto-next
+                  (yas-choose-value
+                  '("stdenv.buildPlatform.canExecute stdenv.hostPlatform;"
+                    "false;")))}

--- a/snippets/nix-mode/passthru_update
+++ b/snippets/nix-mode/passthru_update
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: passthru_update
+# key: pu
+# --
+passthru.updateScript = nix-update-script { };

--- a/snippets/nix-mode/pkgs_mkshell
+++ b/snippets/nix-mode/pkgs_mkshell
@@ -1,0 +1,13 @@
+# -*- mode: snippet -*-
+# name: pkgs_mkshell
+# key: pms
+# --
+pkgs.${1:$$(yas-auto-next (yas-choose-value '("mkShell" "mkShellNoCC")))} {
+  inputsFrom = [ $3 ];
+
+  packages = [ $2 ];
+
+  shellHook = ''
+  $4
+  '';
+}$0

--- a/snippets/nix-ts-mode/.yas-parents
+++ b/snippets/nix-ts-mode/.yas-parents
@@ -1,0 +1,1 @@
+nix-mode


### PR DESCRIPTION
This PR adds a `nix-ts-mode` which inherits all the snippets in `nix-mode` to help nix tree-sitter users.

In addition, 3 new snippets are added:
- `pkg_mkshell`: Adds a skeleton for quickly setting up a `shell.nix`.
- `doCheck`: Adds the `doCheck` attribute to a package derivation based on best practices in nixpkgs
- `passthru_update`: Adds the passthru update script attribute found in many nixpkgs package derivations.