### PR TITLE
improve conversion from header file name to macro

### DIFF
--- a/snippets/c-lang-common/once
+++ b/snippets/c-lang-common/once
@@ -2,7 +2,7 @@
 # name: #ifndef XXX; #define XXX; #endif
 # key: once
 # --
-#ifndef ${1:`(upcase (file-name-nondirectory (file-name-sans-extension (or (buffer-file-name) ""))))`_H}
+#ifndef ${1:`(upcase (replace-regexp-in-string "[^A-Za-z0-9_]" "_" (file-name-nondirectory (or (buffer-file-name)))))`}
 #define $1
 
 $0


### PR DESCRIPTION
Suppose we are in the file `my-header.hpp`. This snippet would expand the once macro to `#define MY-HEADER_H` which is not an ideal expansion because the `MY-HEADER_H` is not a valid macro definition and my file should be `_HPP` (for c++) and not `_H`. With this modification, this snippet will expand:

- my-header.hpp -> MY_HEADER_HPP
- my_header.h -> MY_HEADER_H
- my.header.hxx -> MY_HEADER_HXX