### PR TITLE
Generate UUID in org-mode

### DIFF
--- a/snippets/org-mode/uuid
+++ b/snippets/org-mode/uuid
@@ -1,0 +1,5 @@
+# -*- mode: snippet -*-
+# name: generate uuid
+# key: uuid_
+# --
+`(org-id-uuid)`


### PR DESCRIPTION
This is quite handy in `org-babel` when I want to quickly output image into `$TMPDIR`